### PR TITLE
feat: add environment variable support for Claude Code token limits

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# CLAUDE_CODE_MAX_TOKENS controls the maximum token limit for Claude Code sessions
+# This is used by the Claude Agent SDK to set the context window size for AI analysis
+# Higher values allow for more comprehensive code analysis but consume more tokens
+# Default: 64000 tokens (sufficient for most penetration testing tasks)
+CLAUDE_CODE_MAX_TOKENS=64000

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ WORKDIR /app
 
 # Copy package.json and package-lock.json first for better caching
 COPY package*.json ./
+COPY .env ./.env
 
 # Install Node.js dependencies as root
 RUN npm ci --only=production && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ajv-formats": "^2.1.1",
         "boxen": "^8.0.1",
         "chalk": "^5.0.0",
+        "dotenv": "^16.4.5",
         "figlet": "^1.9.3",
         "gradient-string": "^3.0.0",
         "js-yaml": "^4.1.0",
@@ -436,6 +437,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ajv-formats": "^2.1.1",
     "boxen": "^8.0.1",
     "chalk": "^5.0.0",
+    "dotenv": "^16.4.5",
     "figlet": "^1.9.3",
     "gradient-string": "^3.0.0",
     "js-yaml": "^4.1.0",

--- a/shannon.mjs
+++ b/shannon.mjs
@@ -2,6 +2,9 @@
 
 import { path, fs } from 'zx';
 import chalk from 'chalk';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 // Config and Tools
 import { parseConfig, distributeConfig } from './src/config-parser.js';


### PR DESCRIPTION
Introduces .env file configuration to manage CLAUDE_CODE_MAX_TOKENS, allowing flexible control of the context window size for AI analysis sessions. This enables users to tune token limits based on their specific penetration testing needs without modifying code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)