### PR TITLE
docs: update Discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Every Claude (coder) deserves their Shannon.
 
 ---
 
-[Website](https://keygraph.io) • [Discord](https://discord.gg/u7DRRXrs7H)
+[Website](https://keygraph.io) • [Discord](https://discord.gg/KAqzSHHpRt)
 
 ---
 </div>
@@ -473,7 +473,7 @@ Issues are welcome for bug reports and feature requests.
 
 - 🐛 **Report bugs** via [GitHub Issues](https://github.com/keygraph/shannon/issues)
 - 💡 **Suggest features** in [Discussions](https://github.com/keygraph/shannon/discussions)
-- 💬 **Join our [Discord](https://discord.gg/u7DRRXrs7H)** for real-time community support
+- 💬 **Join our [Discord](https://discord.gg/KAqzSHHpRt)** for real-time community support
 
 ### Stay Connected
 

--- a/xben-benchmark-results/README.md
+++ b/xben-benchmark-results/README.md
@@ -151,7 +151,7 @@ These resources record the benchmark configuration and complete results for all 
 ## Join the Community
 
 - **GitHub:** [KeygraphHQ/shannon](https://github.com/KeygraphHQ/shannon)
-- **Discord:** [Join our Discord](https://discord.gg/u7DRRXrs7H)
+- **Discord:** [Join our Discord](https://discord.gg/KAqzSHHpRt)
 - **Twitter/X:** [@KeygraphHQ](https://x.com/KeygraphHQ)
 - **Enterprise inquiries:** [shannon@keygraph.io](mailto:shannon@keygraph.io)
 


### PR DESCRIPTION
## Summary
- Updated Discord invite link code to `KAqzSHHpRt` across all README files

## Files Changed
- `README.md`
- `xben-benchmark-results/README.md`