### PR TITLE
feat: add Ollama support for local model usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,18 @@ ANTHROPIC_API_KEY=your-api-key-here
 # OPENROUTER_API_KEY=sk-or-your-openrouter-key
 # ROUTER_DEFAULT=openrouter,google/gemini-3-flash-preview
 
+# --- Ollama (local models via OpenAI-compatible API) ---
+# First, run: ollama serve
+# Then set the base URL to your Ollama instance:
+# OLLAMA_BASE_URL=http://localhost:11434/v1
+# ROUTER_DEFAULT=ollama,llama3.3:70b
+#
+# For Docker, use host.docker.internal:
+# OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
+
 # =============================================================================
 # Available Models
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini
 # OpenRouter: google/gemini-3-flash-preview
+# Ollama:     llama3.3:70b, qwen2.5:72b, deepseek-r1:70b (or any model you have pulled)

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ If your application uses two-factor authentication, simply add the TOTP secret t
 Shannon can experimentally route requests through alternative AI providers using claude-code-router. This mode is not officially supported and is intended primarily for:
 
 * **Model experimentation** — try Shannon with GPT-5.2 or Gemini 3–family models
+* **Local model usage** — run Shannon with Ollama for privacy or cost savings
 
 #### Quick Setup
 
@@ -282,12 +283,48 @@ ROUTER_DEFAULT=openai,gpt-5.2  # provider,model format
 ./shannon start URL=https://example.com REPO=/path/to/repo ROUTER=true
 ```
 
+#### Ollama (Local Models)
+
+Shannon supports Ollama for running local models. Ollama provides an OpenAI-compatible API that Shannon can use via router mode.
+
+1. Install and run Ollama:
+
+```bash
+# Install Ollama (https://ollama.ai)
+# Pull a capable model (70B+ recommended for security analysis)
+ollama pull llama3.3:70b
+
+# Start Ollama server
+ollama serve
+```
+
+2. Configure `.env`:
+
+```bash
+# For local development:
+OLLAMA_BASE_URL=http://localhost:11434/v1
+ROUTER_DEFAULT=ollama,llama3.3:70b
+
+# For Docker (use host.docker.internal to reach host machine):
+OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
+ROUTER_DEFAULT=ollama,llama3.3:70b
+```
+
+3. Run with `ROUTER=true`:
+
+```bash
+./shannon start URL=https://example.com REPO=/path/to/repo ROUTER=true
+```
+
+> **Note:** Ollama models require significant compute resources. For best results, use 70B+ parameter models with adequate GPU memory.
+
 #### Experimental Models
 
-| Provider | Models |
-|----------|--------|
-| OpenAI | gpt-5.2, gpt-5-mini |
-| OpenRouter | google/gemini-3-flash-preview |
+| Provider | Models | Notes |
+|----------|--------|-------|
+| OpenAI | gpt-5.2, gpt-5-mini | Cloud API |
+| OpenRouter | google/gemini-3-flash-preview | Cloud API |
+| Ollama | llama3.3:70b, qwen2.5:72b, deepseek-r1:70b | Local, any pulled model |
 
 #### Disclaimer
 

--- a/src/ai/router-utils.ts
+++ b/src/ai/router-utils.ts
@@ -32,3 +32,23 @@ export function getActualModelName(sdkReportedModel?: string): string | undefine
 export function isRouterMode(): boolean {
   return !!process.env.ANTHROPIC_BASE_URL && !!process.env.ROUTER_DEFAULT;
 }
+
+/**
+ * Check if Ollama mode is active.
+ * Ollama uses a separate base URL since it provides an OpenAI-compatible API directly.
+ */
+export function isOllamaMode(): boolean {
+  return !!process.env.OLLAMA_BASE_URL && !!process.env.ROUTER_DEFAULT;
+}
+
+/**
+ * Get the provider name from ROUTER_DEFAULT.
+ * Returns the first part of the "provider,model" format.
+ */
+export function getProviderName(): string | undefined {
+  const routerDefault = process.env.ROUTER_DEFAULT;
+  if (!routerDefault) return undefined;
+
+  const parts = routerDefault.split(',');
+  return parts[0];
+}


### PR DESCRIPTION
## Summary
- Add Ollama as an experimental router provider option, enabling users to run Shannon with local models for privacy or cost savings
- Add `OLLAMA_BASE_URL` configuration to `.env.example`
- Add helper functions `isOllamaMode()` and `getProviderName()` to `router-utils.ts`
- Document Ollama setup in README with Docker considerations (using `host.docker.internal`)

## Test plan
- [ ] Configure Ollama with a 70B+ model (e.g., `llama3.3:70b`)
- [ ] Set `OLLAMA_BASE_URL` and `ROUTER_DEFAULT` in `.env`
- [ ] Run Shannon with `ROUTER=true` flag
- [ ] Verify requests are routed to Ollama endpoint

Closes #61