### PR TITLE
feat: add report language support for i18n output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,11 @@ ANTHROPIC_API_KEY=your-api-key-here
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini
 # OpenRouter: google/gemini-3-flash-preview
+
+# =============================================================================
+# Report Settings
+# =============================================================================
+# Language for report output (optional)
+# Supported: en, zh, zh-cn, zh-tw, es, ja, ko, fr, de, pt, ru, ar, hi, it, nl, pl, tr, vi, th
+# Or specify any language name (e.g., "Vietnamese", "Thai")
+# REPORT_LANGUAGE=en

--- a/README.md
+++ b/README.md
@@ -256,6 +256,45 @@ rules:
 
 If your application uses two-factor authentication, simply add the TOTP secret to your config file. The AI will automatically generate the required codes during testing.
 
+#### Report Language
+
+Shannon can generate reports in different languages. Set the language via environment variable or config file:
+
+**Option 1: Environment variable**
+
+```bash
+export REPORT_LANGUAGE=zh  # Chinese
+./shannon start URL=https://example.com REPO=/path/to/repo
+```
+
+**Option 2: Config file**
+
+```yaml
+# In your config.yaml
+report_language: ja  # Japanese
+```
+
+**Supported language codes:**
+
+| Code | Language |
+|------|----------|
+| en | English (default) |
+| zh, zh-cn | Chinese (Simplified) |
+| zh-tw | Chinese (Traditional) |
+| es | Spanish |
+| ja | Japanese |
+| ko | Korean |
+| fr | French |
+| de | German |
+| pt | Portuguese |
+| ru | Russian |
+| ar | Arabic |
+| hi | Hindi |
+| vi | Vietnamese |
+| th | Thai |
+
+You can also specify any language name directly (e.g., `report_language: Vietnamese`).
+
 ### [EXPERIMENTAL - UNSUPPORTED] Router Mode (Alternative Providers)
 
 Shannon can experimentally route requests through alternative AI providers using claude-code-router. This mode is not officially supported and is intended primarily for:

--- a/configs/config-schema.json
+++ b/configs/config-schema.json
@@ -105,12 +105,19 @@
       "type": "object",
       "description": "Deprecated: Use 'authentication' section instead",
       "deprecated": true
+    },
+    "report_language": {
+      "type": "string",
+      "description": "Language for report output (e.g., 'en', 'zh', 'es', 'ja', 'ko', 'fr', 'de')",
+      "minLength": 2,
+      "maxLength": 50
     }
   },
   "anyOf": [
     {"required": ["authentication"]},
     {"required": ["rules"]},
-    {"required": ["authentication", "rules"]}
+    {"required": ["authentication", "rules"]},
+    {"required": ["report_language"]}
   ],
   "additionalProperties": false,
   "$defs": {

--- a/src/config-parser.ts
+++ b/src/config-parser.ts
@@ -330,11 +330,14 @@ export const distributeConfig = (config: Config | null): DistributedConfig => {
   const avoid = config?.rules?.avoid || [];
   const focus = config?.rules?.focus || [];
   const authentication = config?.authentication || null;
+  // Report language can come from config file or REPORT_LANGUAGE env var
+  const reportLanguage = config?.report_language || process.env.REPORT_LANGUAGE || null;
 
   return {
     avoid: avoid.map(sanitizeRule),
     focus: focus.map(sanitizeRule),
     authentication: authentication ? sanitizeAuthentication(authentication) : null,
+    reportLanguage: reportLanguage ? reportLanguage.trim() : null,
   };
 };
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -54,10 +54,12 @@ export interface Config {
   rules?: Rules;
   authentication?: Authentication;
   login?: unknown; // Deprecated
+  report_language?: string; // Language for report output (e.g., 'en', 'zh', 'es', 'ja')
 }
 
 export interface DistributedConfig {
   avoid: Rule[];
   focus: Rule[];
   authentication: Authentication | null;
+  reportLanguage: string | null;
 }


### PR DESCRIPTION
## Summary
Add support for generating security reports in different languages via:
- `REPORT_LANGUAGE` environment variable
- `report_language` config file option

## Changes
- Add `report_language` field to `Config` and `DistributedConfig` types
- Add `report_language` to JSON schema validation
- Update `distributeConfig` to read from config or environment variable
- Add `buildLanguageInstruction()` in prompt-manager to inject language instructions into prompts
- Update `.env.example` with `REPORT_LANGUAGE` option
- Document language support in README with supported language codes table

## Supported Languages
| Code | Language |
|------|----------|
| en | English (default) |
| zh, zh-cn | Chinese (Simplified) |
| zh-tw | Chinese (Traditional) |
| es | Spanish |
| ja | Japanese |
| ko | Korean |
| fr | French |
| de | German |
| pt | Portuguese |
| And more... |

## Usage
```bash
# Via environment variable
export REPORT_LANGUAGE=zh
./shannon start URL=https://example.com REPO=/path/to/repo

# Via config file
report_language: ja
```

## Test plan
- [ ] Set `REPORT_LANGUAGE=zh` and verify report is generated in Chinese
- [ ] Set `report_language: ja` in config file and verify Japanese output
- [ ] Verify default (no language set) produces English report

Closes #60