### PR TITLE
fix: improve error messaging for agent output validation failures

### DIFF
--- a/src/ai/claude-executor.ts
+++ b/src/ai/claude-executor.ts
@@ -181,6 +181,15 @@ export async function validateAgentOutput(
       console.log(chalk.green(`    Validation passed: Required files/structure present`));
     } else {
       console.log(chalk.red(`    Validation failed: Missing required deliverable files`));
+      // Log which file is expected for common agents to help with debugging
+      const expectedFiles: Record<string, string> = {
+        'pre-recon': 'deliverables/code_analysis_deliverable.md',
+        'recon': 'deliverables/recon_deliverable.md',
+        'report': 'deliverables/comprehensive_security_assessment_report.md',
+      };
+      if (agentName && expectedFiles[agentName]) {
+        console.log(chalk.yellow(`    Expected file: ${sourceDir}/${expectedFiles[agentName]}`));
+      }
     }
 
     return validationResult;

--- a/src/temporal/activities.ts
+++ b/src/temporal/activities.ts
@@ -229,8 +229,18 @@ async function runAgentActivity(
 
       // Limit output validation retries (unlikely to self-heal)
       if (attemptNumber >= MAX_OUTPUT_VALIDATION_RETRIES) {
+        // Build helpful troubleshooting message
+        const troubleshootingTips = agentName === 'pre-recon'
+          ? `\n\nTroubleshooting tips:
+  1. Check if the repository path is accessible: ${repoPath}
+  2. If using ROUTER mode, ensure the model supports tool use and follows instructions well
+  3. Check agent logs at: audit-logs/*/agents/${agentName}*.jsonl
+  4. Try running with a different model (Claude models recommended)
+  5. Ensure the target URL is reachable from the Docker container`
+          : '';
+
         throw ApplicationFailure.nonRetryable(
-          `Agent ${agentName} failed output validation after ${attemptNumber} attempts`,
+          `Agent ${agentName} failed output validation after ${attemptNumber} attempts. Required deliverable files were not created.${troubleshootingTips}`,
           'OutputValidationError',
           [{ agentName, attemptNumber, elapsed: Date.now() - startTime }]
         );


### PR DESCRIPTION
## Summary
Improve error messages when agents fail to create required deliverable files, making it easier to diagnose and fix common issues.

## Problem
When the pre-recon agent (or other agents) fail to create required deliverable files, users see a generic error:
```
Agent pre-recon failed output validation after 3 attempts
```

This doesn't help users understand what went wrong or how to fix it.

## Solution
Add troubleshooting tips and more detailed logging:

1. **Troubleshooting tips in error message** (for pre-recon agent):
   - Check if repository path is accessible
   - If using ROUTER mode, ensure model supports tool use
   - Check agent logs location
   - Try Claude models (recommended)
   - Ensure target URL is reachable from Docker

2. **Log expected file path** when validation fails:
   ```
   Expected file: /path/to/repo/deliverables/code_analysis_deliverable.md
   ```

## Common causes this helps diagnose
- Using router mode with models that don't follow instructions well
- Repository path not accessible from Docker container
- Target URL not reachable (should use `host.docker.internal` for local apps)

## Test plan
- [ ] Run Shannon with an intentionally inaccessible repo path
- [ ] Verify improved error message appears with troubleshooting tips
- [ ] Verify expected file path is logged on validation failure

Fixes #62