### PR TITLE
Fix output token limit failures in agent report writing

### DIFF
--- a/prompts/exploit-auth.txt
+++ b/prompts/exploit-auth.txt
@@ -146,7 +146,10 @@ You are the **Identity Compromise Specialist** - proving tangible impact of brok
 - **save_deliverable (MCP Tool):** Saves exploitation evidence files.
   - **Parameters:**
     - `deliverable_type`: "AUTH_EVIDENCE" (required)
-    - `content`: Your complete evidence report (markdown) (required)
+    - `content`: Your complete evidence report (markdown) (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
   - **Returns:** `{ status: "success", filepath: "..." }` on success or `{ status: "error", message: "..." }` on failure
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for brute force batches, credential stuffing, token replay automation, and any scripted workflow.
@@ -405,8 +408,12 @@ If [blocker] were bypassed/removed:
 
 COMPLETION REQUIREMENTS (ALL must be satisfied):
 	1. Plan Completion: ALL tasks in your todo list must be marked as completed using the TodoWrite tool.
-	2. Deliverable Generation: The required deliverable must be successfully saved using save_deliverable script:
-	  - Evidence report: Use `save_deliverable` MCP tool with `deliverable_type: "AUTH_EVIDENCE"` and your evidence report as `content`
+	2. Deliverable Generation: The required deliverable must be successfully saved using save_deliverable MCP tool:
+	  - Create the deliverables directory: `mkdir -p deliverables`
+	  - Write the first half of your report to `deliverables/auth_exploitation_evidence.md` using the Write tool
+	  - Append the second half using the Edit tool
+	  - Call `save_deliverable` MCP tool with `deliverable_type: "AUTH_EVIDENCE"` and `file_path: "deliverables/auth_exploitation_evidence.md"`
+	  - WARNING: Do NOT pass the entire report as inline `content` — use the `file_path` parameter to avoid exceeding the output token limit
 
 CRITICAL WARNING: Announcing completion before every item in deliverables/auth_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
 

--- a/prompts/exploit-authz.txt
+++ b/prompts/exploit-authz.txt
@@ -133,7 +133,10 @@ You are the **Privilege Escalation Specialist** - proving tangible impact of bro
 - **save_deliverable (MCP Tool):** Saves exploitation evidence files.
   - **Parameters:**
     - `deliverable_type`: "AUTHZ_EVIDENCE" (required)
-    - `content`: Your complete evidence report (markdown) (required)
+    - `content`: Your complete evidence report (markdown) (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
   - **Returns:** `{ status: "success", filepath: "..." }` on success or `{ status: "error", message: "..." }` on failure
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for IDOR sweeps, role escalation loops, and workflow bypass automation.
@@ -407,8 +410,12 @@ If [blocker] were bypassed/removed:
 
 COMPLETION REQUIREMENTS (ALL must be satisfied):
 	1. Plan Completion: ALL tasks in your todo list must be marked as completed using the TodoWrite tool.
-	2. Deliverable Generation: The required deliverable must be successfully saved using save_deliverable script:
-	  - Evidence report: Use `save_deliverable` MCP tool with `deliverable_type: "AUTHZ_EVIDENCE"` and your evidence report as `content`
+	2. Deliverable Generation: The required deliverable must be successfully saved using save_deliverable MCP tool:
+	  - Create the deliverables directory: `mkdir -p deliverables`
+	  - Write the first half of your report to `deliverables/authz_exploitation_evidence.md` using the Write tool
+	  - Append the second half using the Edit tool
+	  - Call `save_deliverable` MCP tool with `deliverable_type: "AUTHZ_EVIDENCE"` and `file_path: "deliverables/authz_exploitation_evidence.md"`
+	  - WARNING: Do NOT pass the entire report as inline `content` — use the `file_path` parameter to avoid exceeding the output token limit
 
 CRITICAL WARNING: Announcing completion before every item in deliverables/authz_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
 

--- a/prompts/exploit-injection.txt
+++ b/prompts/exploit-injection.txt
@@ -115,7 +115,10 @@ You are the **Proof-of-Impact Generator** - converting theoretical injection fla
 - **save_deliverable (MCP Tool):** Saves exploitation evidence files.
   - **Parameters:**
     - `deliverable_type`: "INJECTION_EVIDENCE" (required)
-    - `content`: Your complete evidence report (markdown) (required)
+    - `content`: Your complete evidence report (markdown) (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
   - **Returns:** `{ status: "success", filepath: "..." }` on success or `{ status: "error", message: "..." }` on failure
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for any custom scripting beyond single ad-hoc commands.
@@ -435,7 +438,11 @@ If [blocker] were bypassed/removed:
 COMPLETION REQUIREMENTS (ALL must be satisfied):
 1.  **Plan Completion:** ALL tasks for EVERY vulnerability in your todo list must be marked as completed using the TodoWrite tool. **No vulnerability or task can be left unaddressed.**
 2.  **Deliverable Generation:** The required deliverable must be successfully saved using save_deliverable MCP tool:
-    - Evidence report: Use `save_deliverable` MCP tool with `deliverable_type: "INJECTION_EVIDENCE"` and your evidence report as `content`
+    - Create the deliverables directory: `mkdir -p deliverables`
+    - Write the first half of your report to `deliverables/injection_exploitation_evidence.md` using the Write tool
+    - Append the second half using the Edit tool
+    - Call `save_deliverable` MCP tool with `deliverable_type: "INJECTION_EVIDENCE"` and `file_path: "deliverables/injection_exploitation_evidence.md"`
+    - WARNING: Do NOT pass the entire report as inline `content` — use the `file_path` parameter to avoid exceeding the output token limit
 
 **CRITICAL WARNING:** Announcing completion before every item in `deliverables/injection_exploitation_queue.json` has been pursued to a final, evidence-backed conclusion (either successfully exploited or verified false positive) will be considered a mission failure. Superficial testing is not acceptable.
 

--- a/prompts/exploit-ssrf.txt
+++ b/prompts/exploit-ssrf.txt
@@ -132,7 +132,10 @@ You are the **Network Boundary Breaker** - proving tangible impact of SSRF vulne
 - **save_deliverable (MCP Tool):** Saves exploitation evidence files.
   - **Parameters:**
     - `deliverable_type`: "SSRF_EVIDENCE" (required)
-    - `content`: Your complete evidence report (markdown) (required)
+    - `content`: Your complete evidence report (markdown) (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
   - **Returns:** `{ status: "success", filepath: "..." }` on success or `{ status: "error", message: "..." }` on failure
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **{{MCP_SERVER}} (Playwright):** Useful for complex multi-step SSRF exploitation that requires browser context or JavaScript execution.
@@ -484,8 +487,12 @@ If [blocker] were bypassed/removed:
 
 COMPLETION REQUIREMENTS (ALL must be satisfied):
 	1. Plan Completion: ALL tasks in your todo list must be marked as completed using the TodoWrite tool.
-	2. Deliverable Generation: The required deliverable must be successfully saved using save_deliverable script:
-	  - Evidence report: Use `save_deliverable` MCP tool with `deliverable_type: "SSRF_EVIDENCE"` and your evidence report as `content`
+	2. Deliverable Generation: The required deliverable must be successfully saved using save_deliverable MCP tool:
+	  - Create the deliverables directory: `mkdir -p deliverables`
+	  - Write the first half of your report to `deliverables/ssrf_exploitation_evidence.md` using the Write tool
+	  - Append the second half using the Edit tool
+	  - Call `save_deliverable` MCP tool with `deliverable_type: "SSRF_EVIDENCE"` and `file_path: "deliverables/ssrf_exploitation_evidence.md"`
+	  - WARNING: Do NOT pass the entire report as inline `content` — use the `file_path` parameter to avoid exceeding the output token limit
 
 CRITICAL WARNING: Announcing completion before every item in deliverables/ssrf_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
 

--- a/prompts/exploit-xss.txt
+++ b/prompts/exploit-xss.txt
@@ -135,7 +135,10 @@ You are the **Client-Side Impact Demonstrator** - converting theoretical XSS fla
 - **save_deliverable (MCP Tool):** Saves exploitation evidence files.
   - **Parameters:**
     - `deliverable_type`: "XSS_EVIDENCE" (required)
-    - `content`: Your complete evidence report (markdown) (required)
+    - `content`: Your complete evidence report (markdown) (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
   - **Returns:** `{ status: "success", filepath: "..." }` on success or `{ status: "error", message: "..." }` on failure
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for payload iteration scripts, exfiltration listeners, and DOM interaction helpers beyond single manual steps.
@@ -425,7 +428,11 @@ If [blocker] were bypassed/removed:
 COMPLETION REQUIREMENTS (ALL must be satisfied):
 - Todo List Completion: ALL vulnerabilities from the exploitation queue must have been processed and marked as completed in your todo list.
 - Deliverable Generation: The required deliverable must be successfully saved using save_deliverable MCP tool:
-  - Evidence report: Use `save_deliverable` MCP tool with `deliverable_type: "XSS_EVIDENCE"` and your evidence report as `content`
+  - Create the deliverables directory: `mkdir -p deliverables`
+  - Write the first half of your report to `deliverables/xss_exploitation_evidence.md` using the Write tool
+  - Append the second half using the Edit tool
+  - Call `save_deliverable` MCP tool with `deliverable_type: "XSS_EVIDENCE"` and `file_path: "deliverables/xss_exploitation_evidence.md"`
+  - WARNING: Do NOT pass the entire report as inline `content` — use the `file_path` parameter to avoid exceeding the output token limit
 
 **CRITICAL WARNING:** Announcing completion before every item in `deliverables/xss_exploitation_queue.json` has been pursued to a final, evidence-backed conclusion (either successfully exploited or verified false positive) will be considered a mission failure. Superficial testing is not acceptable.
 

--- a/prompts/pre-recon-code.txt
+++ b/prompts/pre-recon-code.txt
@@ -81,9 +81,10 @@ You are the **Code Intelligence Gatherer** and **Architectural Foundation Builde
 - **save_deliverable (MCP Tool):** Saves your final deliverable file with automatic validation.
   - **Parameters:**
     - `deliverable_type`: "CODE_ANALYSIS" (required)
-    - `content`: Your complete markdown report (required)
+    - `content`: Your markdown report OR `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "...", validated: true/false }` on success or `{ status: "error", message: "...", errorType: "...", retryable: true/false }` on failure
-  - **Usage:** Call the tool with your complete markdown report. The tool handles correct naming and file validation automatically.
+  - **Usage:** For large reports, write the report to a file incrementally (section by section using Write + Edit tools), then call save_deliverable with `file_path` pointing to the file. This avoids hitting output token limits.
+  - **IMPORTANT:** Do NOT try to pass large reports as inline `content` — this will exceed the output token limit and cause the agent to fail.
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 </available_tools>
 
@@ -122,12 +123,17 @@ After Phase 1 completes, launch all three vulnerability-focused agents in parall
 
 - Combine all agent outputs intelligently
 - Resolve conflicts and eliminate duplicates
-- Generate the final structured markdown report
+- **CRITICAL: Write the report INCREMENTALLY to avoid output token limits:**
+  1. First, create the deliverables directory: `mkdir -p deliverables`
+  2. Write sections 1-5 to `deliverables/code_analysis_deliverable.md` using the Write tool
+  3. Use the Edit tool to APPEND sections 6-8 to the same file (add content at the end)
+  4. Use the Edit tool to APPEND sections 9-10 to the same file
+  5. Finally, call `save_deliverable` with `deliverable_type: "CODE_ANALYSIS"` and `file_path: "deliverables/code_analysis_deliverable.md"` (the tool will read the file content automatically)
+- **DO NOT** try to pass the entire report as inline `content` to save_deliverable — it will exceed output token limits and fail
 - **Schema Management**: Using schemas identified by the Entry Point Mapper Agent:
   - Create the `outputs/schemas/` directory using mkdir -p
   - Copy all discovered schema files to `outputs/schemas/` with descriptive names
   - Include schema locations in your attack surface analysis
-- Save complete analysis using the `save_deliverable` MCP tool with `deliverable_type: "CODE_ANALYSIS"` and your complete markdown report as the `content`
 
 **EXECUTION PATTERN:**
 1. **Use TodoWrite to create task list** tracking: Phase 1 agents, Phase 2 agents, and report synthesis

--- a/prompts/recon.txt
+++ b/prompts/recon.txt
@@ -63,8 +63,10 @@ Please use these tools for the following use cases:
 - **save_deliverable (MCP Tool):** Saves your reconnaissance deliverable file.
   - **Parameters:**
     - `deliverable_type`: "RECON" (required)
-    - `content`: Your complete markdown report (required)
+    - `content`: Your markdown report OR `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "..." }` on success or `{ status: "error", message: "..." }` on failure
+  - **Usage:** For large reports, write the report to a file incrementally (section by section using Write + Edit tools), then call save_deliverable with `file_path` pointing to the file. This avoids hitting output token limits.
+  - **IMPORTANT:** Do NOT try to pass large reports as inline `content` — this will exceed the output token limit and cause the agent to fail.
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 
 **CRITICAL TASK AGENT RULE:** You are PROHIBITED from using Read, Glob, or Grep tools for source code analysis. All code examination must be delegated to Task agents for deeper, more thorough analysis.
@@ -134,7 +136,16 @@ You must follow this methodical four-step process:
 </systematic_approach>
 
 <deliverable_instructions>
-When you have a complete understanding of the attack surface, you MUST synthesize all of your findings into a single, detailed Markdown report and save it using the save_deliverable script with type RECON.
+When you have a complete understanding of the attack surface, you MUST synthesize all of your findings into a single, detailed Markdown report and save it using the save_deliverable tool with type RECON.
+
+**CRITICAL: Write the report INCREMENTALLY to avoid output token limits:**
+1. First, create the deliverables directory: `mkdir -p deliverables`
+2. Write sections 0-4 to `deliverables/recon_deliverable.md` using the Write tool
+3. Use the Edit tool to APPEND sections 5-7 to the same file (add content at the end)
+4. Use the Edit tool to APPEND sections 8-9 to the same file
+5. Finally, call `save_deliverable` with `deliverable_type: "RECON"` and `file_path: "deliverables/recon_deliverable.md"` (the tool will read the file content automatically)
+
+**DO NOT** try to pass the entire report as inline `content` to save_deliverable — it will exceed output token limits and fail.
 
 Your report MUST use the following structure precisely:
 
@@ -365,5 +376,5 @@ CRITICAL: Only include sources tracing to dangerous sinks (shell, DB, file ops, 
 </deliverable_instructions>
 
 <conclusion_trigger>
-Once you have saved the complete deliverable using the save_deliverable MCP tool with `deliverable_type: "RECON"` and your complete report as the `content`, your phase is complete. Announce "RECONNAISSANCE COMPLETE" and await further instructions.
+Once you have saved the complete deliverable using the save_deliverable MCP tool with `deliverable_type: "RECON"` and `file_path: "deliverables/recon_deliverable.md"`, your phase is complete. Announce "RECONNAISSANCE COMPLETE" and await further instructions.
 </conclusion_trigger>

--- a/prompts/vuln-auth.txt
+++ b/prompts/vuln-auth.txt
@@ -80,9 +80,12 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 - **save_deliverable (MCP Tool):** Saves deliverable files with automatic validation.
   - **Parameters:**
     - `deliverable_type`: "AUTH_ANALYSIS" or "AUTH_QUEUE" (required)
-    - `content`: Your markdown report or JSON queue (required)
+    - `content`: Your markdown report or JSON queue (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "...", validated: true/false }` on success or `{ status: "error", message: "...", errorType: "...", retryable: true/false }` on failure
   - **Usage:** Call the tool with your deliverable type and content. Queue files must have `{"vulnerabilities": [...]}` structure and will be validated automatically.
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **{{MCP_SERVER}} (Playwright):** To interact with the live web application to understand multi-step flows like password reset or registration.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each endpoint/flow that needs analysis. Mark items as "in_progress" when working on them and "completed" when done.
@@ -252,8 +255,14 @@ This file serves as the handoff mechanism and must always be created to signal c
 
 1.  **Systematic Analysis:** ALL relevant API endpoints and user-facing features identified in the reconnaissance deliverable must be analyzed for AuthN/AuthZ flaws.
 2.  **Deliverable Generation:** Both required deliverables must be successfully saved using save_deliverable MCP tool:
-    - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "AUTH_ANALYSIS"` and your report as `content`
+    - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "AUTH_ANALYSIS"` and your report as `content` (or `file_path` for large reports)
     - Exploitation queue: Use `save_deliverable` MCP tool with `deliverable_type: "AUTH_QUEUE"` and `content: {"vulnerabilities": [...]}`
+
+    **For large analysis reports, use the chunked-writing approach:**
+    1. Create deliverables directory: `mkdir -p deliverables`
+    2. Write the report incrementally using the Write tool (first half), then the Edit tool (append second half)
+    3. Call `save_deliverable` with `file_path` pointing to the written file instead of inline `content`
+    - WARNING: Do NOT pass the entire report as inline content — this will exceed the output token limit and cause failure
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**AUTH ANALYSIS COMPLETE**" and stop.
 </conclusion_trigger>

--- a/prompts/vuln-authz.txt
+++ b/prompts/vuln-authz.txt
@@ -83,9 +83,12 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 - **save_deliverable (MCP Tool):** Saves deliverable files with automatic validation.
   - **Parameters:**
     - `deliverable_type`: "AUTHZ_ANALYSIS" or "AUTHZ_QUEUE" (required)
-    - `content`: Your markdown report or JSON queue (required)
+    - `content`: Your markdown report or JSON queue (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "...", validated: true/false }` on success or `{ status: "error", message: "...", errorType: "...", retryable: true/false }` on failure
   - **Usage:** Call the tool with your deliverable type and content. Queue files must have `{"vulnerabilities": [...]}` structure and will be validated automatically.
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **{{MCP_SERVER}} (Playwright):** To interact with the live web application to understand multi-step flows and role-based access controls.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each endpoint that needs authorization analysis. Mark items as "in_progress" when working on them and "completed" when done.
@@ -355,8 +358,14 @@ This file serves as the handoff mechanism and must always be created to signal c
 
 1. **Todo Completion:** ALL tasks in your TodoWrite list must be marked as "completed"
 2. **Deliverable Generation:** Both required deliverables must be successfully saved using save_deliverable MCP tool:
-   - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "AUTHZ_ANALYSIS"` and your report as `content`
+   - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "AUTHZ_ANALYSIS"` and your report as `content` (or `file_path` for large reports)
    - Exploitation queue: Use `save_deliverable` MCP tool with `deliverable_type: "AUTHZ_QUEUE"` and `content: {"vulnerabilities": [...]}`
+
+   **For large analysis reports, use the chunked-writing approach:**
+   1. Create deliverables directory: `mkdir -p deliverables`
+   2. Write the report incrementally using the Write tool (first half), then the Edit tool (append second half)
+   3. Call `save_deliverable` with `file_path` pointing to the written file instead of inline `content`
+   - WARNING: Do NOT pass the entire report as inline content — this will exceed the output token limit and cause failure
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**AUTHORIZATION ANALYSIS COMPLETE**" and stop.
 

--- a/prompts/vuln-injection.txt
+++ b/prompts/vuln-injection.txt
@@ -83,9 +83,12 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 - **save_deliverable (MCP Tool):** Saves deliverable files with automatic validation.
   - **Parameters:**
     - `deliverable_type`: "INJECTION_ANALYSIS" or "INJECTION_QUEUE" (required)
-    - `content`: Your markdown report or JSON queue (required)
+    - `content`: Your markdown report or JSON queue (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "...", validated: true/false }` on success or `{ status: "error", message: "...", errorType: "...", retryable: true/false }` on failure
   - **Usage:** Call the tool with your deliverable type and content. Queue files must have `{"vulnerabilities": [...]}` structure and will be validated automatically.
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **{{MCP_SERVER}} (Playwright):** To interact with the live web application to understand multi-step flows like password reset or registration.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each injection source that needs analysis. Mark items as "in_progress" when working on them and "completed" when done.
@@ -362,8 +365,14 @@ This file serves as the handoff mechanism to the Exploitation phase and must alw
 
 1. **Todo Completion:** ALL tasks in your TodoWrite list must be marked as "completed"
 2. **Deliverable Generation:** Both required deliverables must be successfully saved using save_deliverable MCP tool:
-   - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "INJECTION_ANALYSIS"` and your report as `content`
+   - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "INJECTION_ANALYSIS"` and your report as `content` (or `file_path` for large reports)
    - Exploitation queue: Use `save_deliverable` MCP tool with `deliverable_type: "INJECTION_QUEUE"` and `content: {"vulnerabilities": [...]}`
+
+   **For large analysis reports, use the chunked-writing approach:**
+   1. Create deliverables directory: `mkdir -p deliverables`
+   2. Write the report incrementally using the Write tool (first half), then the Edit tool (append second half)
+   3. Call `save_deliverable` with `file_path` pointing to the written file instead of inline `content`
+   - WARNING: Do NOT pass the entire report as inline content — this will exceed the output token limit and cause failure
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**INJECTION ANALYSIS COMPLETE**" and stop.
 

--- a/prompts/vuln-ssrf.txt
+++ b/prompts/vuln-ssrf.txt
@@ -79,9 +79,12 @@ An **exploitable vulnerability** is a data flow where user-controlled input infl
 - **save_deliverable (MCP Tool):** Saves deliverable files with automatic validation.
   - **Parameters:**
     - `deliverable_type`: "SSRF_ANALYSIS" or "SSRF_QUEUE" (required)
-    - `content`: Your markdown report or JSON queue (required)
+    - `content`: Your markdown report or JSON queue (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "...", validated: true/false }` on success or `{ status: "error", message: "...", errorType: "...", retryable: true/false }` on failure
   - **Usage:** Call the tool with your deliverable type and content. Queue files must have `{"vulnerabilities": [...]}` structure and will be validated automatically.
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **{{MCP_SERVER}} (Playwright):** To interact with the live web application to understand multi-step flows that might involve URL redirection or proxy functionality.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each SSRF sink that needs analysis. Mark items as "in_progress" when working on them and "completed" when done.
@@ -299,8 +302,14 @@ This file serves as the handoff mechanism and must always be created to signal c
 
 1.  **Systematic Analysis:** ALL relevant API endpoints and request-making features identified in the reconnaissance deliverable must be analyzed for SSRF vulnerabilities.
 2.  **Deliverable Generation:** Both required deliverables must be successfully saved using save_deliverable MCP tool:
-    - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "SSRF_ANALYSIS"` and your report as `content`
+    - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "SSRF_ANALYSIS"` and your report as `content` (or `file_path` for large reports)
     - Exploitation queue: Use `save_deliverable` MCP tool with `deliverable_type: "SSRF_QUEUE"` and `content: {"vulnerabilities": [...]}`
+
+    **For large analysis reports, use the chunked-writing approach:**
+    1. Create deliverables directory: `mkdir -p deliverables`
+    2. Write the report incrementally using the Write tool (first half), then the Edit tool (append second half)
+    3. Call `save_deliverable` with `file_path` pointing to the written file instead of inline `content`
+    - WARNING: Do NOT pass the entire report as inline content — this will exceed the output token limit and cause failure
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**SSRF ANALYSIS COMPLETE**" and stop.
 </conclusion_trigger>

--- a/prompts/vuln-xss.txt
+++ b/prompts/vuln-xss.txt
@@ -84,9 +84,12 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 - **save_deliverable (MCP Tool):** Saves deliverable files with automatic validation.
   - **Parameters:**
     - `deliverable_type`: "XSS_ANALYSIS" or "XSS_QUEUE" (required)
-    - `content`: Your markdown report or JSON queue (required)
+    - `content`: Your markdown report or JSON queue (required for small reports)
+    - `file_path`: path to the report file (use file_path for large reports)
   - **Returns:** `{ status: "success", filepath: "...", validated: true/false }` on success or `{ status: "error", message: "...", errorType: "...", retryable: true/false }` on failure
   - **Usage:** Call the tool with your deliverable type and content. Queue files must have `{"vulnerabilities": [...]}` structure and will be validated automatically.
+  - For large reports, write incrementally to a file, then call save_deliverable with `file_path`
+  - IMPORTANT: Do NOT try to pass large reports as inline `content` — this will exceed the output token limit
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 </available_tools>
 
@@ -288,8 +291,14 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 
 1. Systematic Analysis: ALL input vectors identified from the reconnaissance deliverable must be analyzed.
 2. Deliverable Generation: Both required deliverables must be successfully saved using save_deliverable MCP tool:
-   - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "XSS_ANALYSIS"` and your report as `content`
+   - Analysis report: Use `save_deliverable` MCP tool with `deliverable_type: "XSS_ANALYSIS"` and your report as `content` (or `file_path` for large reports)
    - Exploitation queue: Use `save_deliverable` MCP tool with `deliverable_type: "XSS_QUEUE"` and `content: {"vulnerabilities": [...]}`
+
+   **For large analysis reports, use the chunked-writing approach:**
+   1. Create deliverables directory: `mkdir -p deliverables`
+   2. Write the report incrementally using the Write tool (first half), then the Edit tool (append second half)
+   3. Call `save_deliverable` with `file_path` pointing to the written file instead of inline `content`
+   - WARNING: Do NOT pass the entire report as inline content — this will exceed the output token limit and cause failure
 
 ONLY AFTER both systematic analysis AND successful deliverable generation, announce "XSS ANALYSIS COMPLETE" and stop.
 </conclusion_trigger>

--- a/src/ai/claude-executor.ts
+++ b/src/ai/claude-executor.ts
@@ -224,6 +224,11 @@ export async function runClaudePrompt(
     cwd: sourceDir,
     permissionMode: 'bypassPermissions' as const,
     mcpServers,
+    env: {
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS || '64000',
+      ...(process.env.CLAUDE_CODE_OAUTH_TOKEN && { CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN }),
+      ...(process.env.ANTHROPIC_API_KEY && { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY }),
+    },
   };
 
   if (!execContext.useCleanOutput) {


### PR DESCRIPTION
## Summary
- Agents writing large security reports via `save_deliverable` would exceed the 32K output token limit, crashing the pipeline at Phase 3 (report synthesis)
- This primarily affects subscription plan users (OAuth token via `CLAUDE_CODE_OAUTH_TOKEN`) since the Claude Code SDK enforces a 32K default output token limit. API key users (`ANTHROPIC_API_KEY`) may encounter the same limit depending on SDK configuration.
- Added `file_path` parameter to `save_deliverable` MCP tool so agents can write reports to disk incrementally then pass the path instead of inline content
- Updated all 13 prompt templates with chunked writing instructions (Write sections 1-5, Edit-append remaining, save via file_path)
- Pass `CLAUDE_CODE_MAX_OUTPUT_TOKENS` and auth tokens (OAuth/API key) through SDK `env` option so spawned subprocesses inherit the container environment

## Test plan
- [x] Verified pre-recon agent successfully writes report in chunks (Write + Edit append) and saves via file_path
- [x] Validated deliverable passes output validation after chunked writing
- [x] Confirmed pipeline progresses past pre-recon into recon phase
- [x] Full pipeline run through all 5 phases