### PR TITLE
Add MiniMax provider configuration via Anthropic-compatible env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Shannon is available in two editions:
 - **AI Provider Credentials** (choose one):
   - **Anthropic API key** (recommended) - Get from [Anthropic Console](https://console.anthropic.com)
   - **Claude Code OAuth token**
+  - **MiniMax API key (Anthropic-compatible)** - Get from [MiniMax Coding Plan](https://platform.minimax.io/subscribe/coding-plan), then set `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic`, and `MODEL=MiniMax-M2.1` (or another supported MiniMax model)
   - **[EXPERIMENTAL - UNSUPPORTED] Alternative providers via Router Mode** - OpenAI or Google Gemini via OpenRouter (see [Router Mode](#experimental---unsupported-router-mode-alternative-providers))
 
 ### Quick Start
@@ -124,6 +125,11 @@ cat > .env << 'EOF'
 ANTHROPIC_API_KEY=your-api-key
 CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 EOF
+
+# MiniMax via Anthropic-compatible API (optional)
+# ANTHROPIC_API_KEY=your-minimax-api-key
+# ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic
+# MODEL=MiniMax-M2.1
 
 # 3. Run a pentest
 ./shannon start URL=https://your-app.com REPO=/path/to/your/repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - MODEL=${MODEL:-}  # Optional: override default Claude model (e.g., MiniMax-M2.1)
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}  # Optional: route through claude-code-router
       - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:-}  # Auth token for router
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-}  # Model name when using router (e.g., "gemini,gemini-2.5-pro")

--- a/src/ai/claude-executor.ts
+++ b/src/ai/claude-executor.ts
@@ -219,7 +219,7 @@ export async function runClaudePrompt(
 
   const mcpServers = buildMcpServers(sourceDir, agentName);
   const options = {
-    model: 'claude-sonnet-4-5-20250929',
+    model: process.env.MODEL || 'claude-sonnet-4-5-20250929',
     maxTurns: 10_000,
     cwd: sourceDir,
     permissionMode: 'bypassPermissions' as const,


### PR DESCRIPTION
## Summary
- make Claude model selection configurable via `MODEL` with a safe fallback to `claude-sonnet-4-5-20250929`
- pass `MODEL` into the worker container environment in `docker-compose.yml`
- add concise README guidance for MiniMax as an Anthropic-compatible provider, including where to get a MiniMax API key and the required env vars (`ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `MODEL`)

## Notes
- changes are surgical and limited to provider/model configuration and docs
- no Router mode changes included