### PR TITLE
docs: add ANTHROPIC_BASE_URL support for custom endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,17 @@ ANTHROPIC_API_KEY=your-api-key-here
 # ROUTER_DEFAULT=openrouter,google/gemini-3-flash-preview
 
 # =============================================================================
+# OPTION 3: Custom Anthropic-Compatible Endpoint (no router)
+# =============================================================================
+# Use any Anthropic-compatible API (Kimi K2.5, AWS Bedrock, etc.) directly
+# without the router. Just set the base URL and your API key:
+#
+# ANTHROPIC_BASE_URL=https://your-custom-endpoint.com/v1
+# ANTHROPIC_API_KEY=your-api-key-for-custom-endpoint
+#
+# Then run normally: ./shannon start URL=<url> REPO=<path>
+
+# =============================================================================
 # Available Models
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,19 @@ The tool should only be used on systems you own or have explicit permission to t
 **Output:**
 - `audit-logs/{hostname}_{sessionId}/` - Session metrics, agent logs, deliverables
 
+### Custom Anthropic-Compatible Endpoint
+
+Use any Anthropic API-compatible endpoint (Kimi K2.5, AWS Bedrock, etc.) without the router:
+
+```bash
+# In .env:
+ANTHROPIC_BASE_URL=https://api.example.com/v1
+ANTHROPIC_API_KEY=your-api-key
+
+# Run normally (no ROUTER=true needed):
+./shannon start URL=<url> REPO=<path>
+```
+
 ### Router Mode (Multi-Model Support)
 
 Shannon supports routing Claude Agent SDK requests through alternative LLM providers via [claude-code-router](https://github.com/musistudio/claude-code-router).

--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ rules:
 
 If your application uses two-factor authentication, simply add the TOTP secret to your config file. The AI will automatically generate the required codes during testing.
 
+### Custom Anthropic-Compatible Endpoint
+
+Use any Anthropic API-compatible endpoint (Kimi K2.5, AWS Bedrock, etc.) without the router:
+
+```bash
+# In .env:
+ANTHROPIC_BASE_URL=https://api.example.com/v1
+ANTHROPIC_API_KEY=your-api-key
+
+# Run normally:
+./shannon start URL=https://example.com REPO=/path/to/repo
+```
+
 ### [EXPERIMENTAL - UNSUPPORTED] Router Mode (Alternative Providers)
 
 Shannon can experimentally route requests through alternative AI providers using claude-code-router. This mode is not officially supported and is intended primarily for:


### PR DESCRIPTION
## Summary
- Add documentation for using custom Anthropic-compatible endpoints
- Users can now set `ANTHROPIC_BASE_URL` in `.env` without router mode
- Enables use of Kimi K2.5, AWS Bedrock, or any Anthropic-compatible API

## Changes
- `.env.example`: Added OPTION 3 section for custom base URL
- `CLAUDE.md`: Added "Custom Anthropic-Compatible Endpoint" section
- `README.md`: Added section before Router Mode

## Test plan
- [ ] Set `ANTHROPIC_BASE_URL` in `.env` to a custom endpoint
- [ ] Run `./shannon start` without `ROUTER=true`
- [ ] Verify requests go to custom endpoint

Fixes #69