### PR TITLE
feat: added support for z.ai coding plan via API as an alternative to anthropic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,14 @@ ANTHROPIC_API_KEY=your-api-key-here
 # ROUTER_DEFAULT=openrouter,google/gemini-3-flash-preview
 
 # =============================================================================
+# OPTION 3: Z.AI GLM Mode (direct Anthropic-compatible endpoint)
+# =============================================================================
+# Enable GLM mode by running: ./shannon start ... GLM=true
+# ZAI_API_KEY=your-zai-api-key
+
+# =============================================================================
 # Available Models
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini
 # OpenRouter: google/gemini-3-flash-preview
+# Z.AI GLM:   glm (via GLM=true flag)

--- a/configs/router-config.json
+++ b/configs/router-config.json
@@ -25,6 +25,15 @@
       "transformer": {
         "use": ["openrouter"]
       }
+    },
+    {
+      "name": "zai",
+      "api_base_url": "https://api.z.ai/api/paas/v4/chat/completions",
+      "api_key": "$ZAI_API_KEY",
+      "models": ["glm"],
+      "transformer": {
+        "use": [["maxcompletiontokens", { "max_completion_tokens": 16384 }]]
+      }
     }
   ],
   "Router": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}  # Optional: route through claude-code-router
       - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:-}  # Auth token for router
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-}  # Model name when using router (e.g., "gemini,gemini-2.5-pro")
+      - ZAI_API_KEY=${ZAI_API_KEY:-}
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - CLAUDE_CODE_MAX_OUTPUT_TOKENS=${CLAUDE_CODE_MAX_OUTPUT_TOKENS:-64000}
     depends_on:
@@ -59,6 +60,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - ZAI_API_KEY=${ZAI_API_KEY:-}
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-openai,gpt-4o}
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3456/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]

--- a/shannon
+++ b/shannon
@@ -36,6 +36,7 @@ Options for 'start':
   OUTPUT=<path>          Output directory for reports (default: ./audit-logs/)
   PIPELINE_TESTING=true  Use minimal prompts for fast testing
   ROUTER=true            Route requests through claude-code-router (multi-model support)
+  GLM=true               Use Z.AI GLM model via direct API endpoint
 
 Options for 'stop':
   CLEAN=true             Remove all data including volumes
@@ -46,6 +47,7 @@ Examples:
   ./shannon start URL=https://example.com REPO=/path/to/repo OUTPUT=./my-reports
   ./shannon logs ID=example.com_shannon-1234567890
   ./shannon query ID=shannon-1234567890
+  ./shannon start URL=https://example.com REPO=/path/to/repo GLM=true
   ./shannon stop CLEAN=true
 
 Monitor workflows at http://localhost:8233
@@ -65,6 +67,7 @@ parse_args() {
       PIPELINE_TESTING=*) PIPELINE_TESTING="${arg#PIPELINE_TESTING=}" ;;
       REBUILD=*) REBUILD="${arg#REBUILD=}" ;;
       ROUTER=*) ROUTER="${arg#ROUTER=}" ;;
+      GLM=*) GLM="${arg#GLM=}" ;;
     esac
   done
 }
@@ -128,9 +131,12 @@ cmd_start() {
     if [ "$ROUTER" = "true" ] && { [ -n "$OPENAI_API_KEY" ] || [ -n "$OPENROUTER_API_KEY" ]; }; then
       # Router mode with alternative provider - set a placeholder for SDK init
       export ANTHROPIC_API_KEY="router-mode"
+    elif [ "$GLM" = "true" ] && [ -n "$ZAI_API_KEY" ]; then
+      export ANTHROPIC_API_KEY="glm-mode"
     else
       echo "ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in .env"
       echo "       (or use ROUTER=true with OPENAI_API_KEY or OPENROUTER_API_KEY)"
+      echo "       (or use GLM=true with ZAI_API_KEY)"
       exit 1
     fi
   fi
@@ -156,6 +162,22 @@ cmd_start() {
     mkdir -p "$OUTPUT"
     chmod 777 "$OUTPUT"
     export OUTPUT_DIR="$OUTPUT"
+  fi
+
+  # Handle GLM flag - direct Anthropic-compatible endpoint via Z.AI
+  if [ "$GLM" = "true" ]; then
+    if [ -z "$ZAI_API_KEY" ]; then
+      echo "ERROR: ZAI_API_KEY is required when using GLM=true"
+      exit 1
+    fi
+    echo "Using Z.AI GLM model via Anthropic-compatible endpoint..."
+    export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"
+    export ANTHROPIC_AUTH_TOKEN="$ZAI_API_KEY"
+    export ROUTER_DEFAULT="zai,glm"
+    if [ "$ROUTER" = "true" ]; then
+      echo "WARNING: GLM=true and ROUTER=true are mutually exclusive. Using GLM direct mode."
+      ROUTER=""
+    fi
   fi
 
   # Handle ROUTER flag - start claude-code-router for multi-model support

--- a/src/ai/router-utils.ts
+++ b/src/ai/router-utils.ts
@@ -27,8 +27,15 @@ export function getActualModelName(sdkReportedModel?: string): string | undefine
 }
 
 /**
- * Check if router mode is active.
+ * Check if GLM direct mode is active (Z.AI Anthropic-compatible endpoint).
+ */
+export function isGlmDirectMode(): boolean {
+  return process.env.ANTHROPIC_BASE_URL?.includes('api.z.ai') ?? false;
+}
+
+/**
+ * Check if router mode is active (excludes GLM direct mode).
  */
 export function isRouterMode(): boolean {
-  return !!process.env.ANTHROPIC_BASE_URL && !!process.env.ROUTER_DEFAULT;
+  return !!process.env.ANTHROPIC_BASE_URL && !!process.env.ROUTER_DEFAULT && !isGlmDirectMode();
 }


### PR DESCRIPTION
## Summary

Added support for Z.AI's GLM coding plan as an alternative LLM provider, allowing Shannon to run penetration tests using Z.AI's Anthropic-compatible API endpoint instead of direct Anthropic API or the router-based multi-model setup.

## Changes

### 1. New `GLM=true` CLI flag (`shannon`)
- Added `GLM=true` option to the `shannon` CLI script
- When enabled, configures the Anthropic SDK to route through Z.AI's Anthropic-compatible endpoint (`https://api.z.ai/api/anthropic`)
- Sets `ANTHROPIC_AUTH_TOKEN` from `ZAI_API_KEY` for authentication
- Handles mutual exclusivity with `ROUTER=true` (GLM takes priority with a warning)
- Added validation that `ZAI_API_KEY` is set when `GLM=true`
- Added fallback placeholder `ANTHROPIC_API_KEY="glm-mode"` to satisfy SDK initialization

### 2. Router config update (`configs/router-config.json`)
- Added `zai` provider configuration pointing to `https://api.z.ai/api/paas/v4/chat/completions`
- Configured with `max_completion_tokens: 16384` transformer
- Uses `$ZAI_API_KEY` environment variable for authentication

### 3. Docker environment passthrough (`docker-compose.yml`)
- Added `ZAI_API_KEY` to both `shannon-worker` and `claude-code-router` services

### 4. GLM detection utility (`src/ai/router-utils.ts`)
- Added `isGlmDirectMode()` function to detect when Z.AI direct mode is active (checks if `ANTHROPIC_BASE_URL` contains `api.z.ai`)
- Updated `isRouterMode()` to exclude GLM direct mode, preventing it from being incorrectly treated as router mode

### 5. Environment example (`.env.example`)
- Added `OPTION 3: Z.AI GLM Mode` section with `ZAI_API_KEY` placeholder
- Documented the `GLM=true` flag usage

## Usage

```bash
# Set in .env
ZAI_API_KEY=your-zai-api-key

# Run with GLM mode
./shannon start URL=https://example.com REPO=/path/to/repo GLM=true
```

## Files Changed

| File | Changes |
|------|---------|
| `shannon` | +22 lines — CLI flag parsing, validation, endpoint configuration |
| `src/ai/router-utils.ts` | +9/-2 — GLM detection + router mode fix |
| `configs/router-config.json` | +9 — Z.AI provider config |
| `docker-compose.yml` | +2 — ZAI_API_KEY env passthrough |
| `.env.example` | +7 — Documentation and example |

## Test Plan

- [ ] Run `./shannon start URL=<url> REPO=<path> GLM=true` with a valid `ZAI_API_KEY`
- [ ] Verify error when `GLM=true` is set without `ZAI_API_KEY`
- [ ] Verify `GLM=true` takes priority over `ROUTER=true` with a warning
- [ ] Confirm `isGlmDirectMode()` returns true when Z.AI endpoint is configured
- [ ] Confirm `isRouterMode()` returns false in GLM direct mode
