### PR TITLE
Fix elapsed time always showing "0s" in query output

### DIFF
--- a/src/temporal/query.ts
+++ b/src/temporal/query.ts
@@ -113,7 +113,11 @@ async function queryWorkflow(): Promise<void> {
     console.log(
       `${chalk.white('Current Agent:')} ${progress.currentAgent || 'none'}`
     );
-    console.log(`${chalk.white('Elapsed:')} ${formatDuration(progress.elapsedMs)}`);
+    // Compute elapsed from startTime on client side (workflow's Date.now() is deterministic, not wall-clock)
+    const elapsedMs = progress.status === 'running'
+      ? Date.now() - progress.startTime
+      : progress.elapsedMs;
+    console.log(`${chalk.white('Elapsed:')} ${formatDuration(elapsedMs)}`);
     console.log(
       `${chalk.white('Completed:')} ${progress.completedAgents.length}/13 agents`
     );


### PR DESCRIPTION
## Summary
- `./shannon query` always displayed "Elapsed: 0s" regardless of how long the workflow had been running
- Root cause: Temporal's deterministic sandbox overrides `Date.now()` inside workflows to return replay-safe timestamps, so `elapsedMs` computed workflow-side is always 0
- Fix: compute elapsed time on the client side using `Date.now() - progress.startTime` for running workflows, falling back to the workflow-reported `elapsedMs` for completed
ones