### PR TITLE
Fix: mount configs directory into worker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       temporal:
         condition: service_healthy
     volumes:
+      - ./configs:/app/configs:ro
       - ./prompts:/app/prompts
       - ./audit-logs:/app/audit-logs
       - ${OUTPUT_DIR:-./audit-logs}:/app/output


### PR DESCRIPTION
## Summary
- The README documents `CONFIG=./configs/my-config.yaml` as a usage example, but this fails at runtime with "Configuration file not found" because the `configs/` directory was never mounted into the worker container
- Add `./configs:/app/configs:ro` volume mount to the worker service, consistent with how `./prompts` is already mounted