### PR TITLE
Support Claude Code OAuth login (no API key needed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,15 @@
 CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 
 # =============================================================================
-# OPTION 1: Direct Anthropic (default, no router)
+# OPTION 1: Claude Code login (easiest — no API key needed)
 # =============================================================================
-ANTHROPIC_API_KEY=your-api-key-here
+# Just run `claude login` on the host. Shannon mounts ~/.claude into Docker
+# automatically. You only need this file with the line above.
+
+# =============================================================================
+# OPTION 2: Direct Anthropic API key
+# =============================================================================
+# ANTHROPIC_API_KEY=your-api-key-here
 
 # OR use OAuth token instead
 # CLAUDE_CODE_OAUTH_TOKEN=your-oauth-token-here

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Shannon is available in two editions:
 
 - **Docker** - Container runtime ([Install Docker](https://docs.docker.com/get-docker/))
 - **AI Provider Credentials** (choose one):
-  - **Anthropic API key** (recommended) - Get from [Anthropic Console](https://console.anthropic.com)
+  - **Claude Code login** (easiest) - Just run `claude login` on the host
+  - **Anthropic API key** - Get from [Anthropic Console](https://console.anthropic.com)
   - **Claude Code OAuth token**
   - **[EXPERIMENTAL - UNSUPPORTED] Alternative providers via Router Mode** - OpenAI or Google Gemini via OpenRouter (see [Router Mode](#experimental---unsupported-router-mode-alternative-providers))
 
@@ -117,11 +118,17 @@ cd shannon
 
 # 2. Configure credentials (choose one method)
 
-# Option A: Export environment variables
+# Option A: Use Claude Code login (easiest — no API key needed)
+claude login
+cat > .env << 'EOF'
+CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
+EOF
+
+# Option B: Export environment variables
 export ANTHROPIC_API_KEY="your-api-key"              # or CLAUDE_CODE_OAUTH_TOKEN
 export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000           # recommended
 
-# Option B: Create a .env file
+# Option C: Create a .env file with API key
 cat > .env << 'EOF'
 ANTHROPIC_API_KEY=your-api-key
 CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000


### PR DESCRIPTION
Lets you run Shannon with just `claude login` on the host — no API key needed.

### What changed

- **docker-compose.yml** — mount host `~/.claude` into the worker container so the Claude Code subprocess can find OAuth credentials
- **shannon** — fall back to `~/.claude/.credentials.json` in the auth check before erroring out
- **README.md** — document `claude login` as the easiest auth option
- **.env.example** — add `claude login` as option 1

### Why not read-only mount?

Claude Code writes debug logs to `~/.claude/debug/`. A `:ro` mount crashes it with `EROFS: read-only file system`.

### Tested

Ran `./shannon start` with no API key in `.env`, just `claude login` credentials on the host. Workflow started and pre-recon agent ran 150+ turns successfully.