### PR TITLE
feat: Add Custom Anthropic Model Option Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Shannon is available in two editions:
   - [Usage Examples](#usage-examples)
   - [Configuration (Optional)](#configuration-optional)
   - [[EXPERIMENTAL - UNSUPPORTED] Router Mode (Alternative Providers)](#experimental---unsupported-router-mode-alternative-providers)
+  - [Custom Anthropic Endpoint](#custom-anthropic-endpoint)
   - [Output and Results](#output-and-results)
 - [Sample Reports](#-sample-reports)
 - [Architecture](#️-architecture)
@@ -294,6 +295,26 @@ ROUTER_DEFAULT=openai,gpt-5.2  # provider,model format
 #### Disclaimer
 
 This feature is experimental and unsupported. Output quality depends heavily on the model. Shannon is built on top of the Anthropic Agent SDK and is optimized and primarily tested with Anthropic Claude models. Alternative providers may produce inconsistent results (including failing early phases like Recon) depending on the model and routing setup.
+
+### Custom Anthropic Endpoint
+
+Shannon supports custom Anthropic-compatible API endpoints with configurable model names. This is useful for:
+
+* **Proxied Anthropic access** — route through corporate proxies or API gateways
+* **Custom deployments** — use self-hosted or alternative Anthropic-compatible endpoints
+* **Model selection** — specify a different Claude model than the default
+
+#### Configuration
+
+Add to your `.env` file:
+
+```bash
+ANTHROPIC_API_KEY=your-api-key
+ANTHROPIC_BASE_URL=https://your-custom-endpoint.com  # Optional: custom endpoint
+ANTHROPIC_MODEL=claude-sonnet-4-5-20250929     # Optional: custom model name
+```
+
+The `ANTHROPIC_MODEL` environment variable overrides the default model (`claude-sonnet-4-5-20250929`). Your endpoint must support the specified model.
 
 ### Output and Results
 


### PR DESCRIPTION
## Add Configurable Claude Model via Environment Variable

  ### Problem

  The Claude model was hardcoded to `claude-sonnet-4-5-20250929` in `src/ai/claude-executor.ts`. Users with custom Anthropic-compatible endpoints
   (proxies, API gateways, or alternative deployments) had no way to specify a different model name, even when their endpoint required it.

  ### Solution

  Introduce the `ANTHROPIC_MODEL` environment variable that allows users to override the default model. This works seamlessly with the existing
  `ANTHROPIC_BASE_URL` support, enabling full customization of both the endpoint and the model.

  ### Changes

  | File | Change |
  |------|--------|
  | `src/ai/claude-executor.ts` | Use `process.env.ANTHROPIC_MODEL` with fallback to default model |
  | `docker-compose.yml` | Pass `ANTHROPIC_MODEL` environment variable to worker container |
  | `.env.example` | Add "Option 3" documentation for custom endpoint + model configuration |
  | `README.md` | Add "Custom Anthropic Endpoint" section with usage instructions |

  ### Usage

  ```bash
  # In .env
  ANTHROPIC_API_KEY=your-api-key
  ANTHROPIC_BASE_URL=https://your-custom-endpoint.com  # Optional
  ANTHROPIC_MODEL=claude-sonnet-4-5-20250929              # Optional

  # Run
  ./shannon start URL=https://example.com REPO=/path/to/repo

  If ANTHROPIC_MODEL is not set, the default claude-sonnet-4-5-20250929 is used.