### PR TITLE
fix: ensure deliverables directory is writable by container user

### DIFF
--- a/mcp-server/src/utils/file-operations.ts
+++ b/mcp-server/src/utils/file-operations.ts
@@ -29,7 +29,7 @@ export function saveDeliverableFile(targetDir: string, filename: string, content
   try {
     mkdirSync(deliverablesDir, { recursive: true });
   } catch {
-    // Directory might already exist, ignore
+    throw new Error(`Cannot create deliverables directory at ${deliverablesDir}`);
   }
 
   // Write file (atomic write - single operation)

--- a/shannon
+++ b/shannon
@@ -194,6 +194,12 @@ cmd_start() {
   mkdir -p ./audit-logs
   chmod 777 ./audit-logs
 
+  # Ensure repo deliverables directory is writable by container user (UID 1001)
+  if [ -d "./repos/$REPO" ]; then
+    mkdir -p "./repos/$REPO/deliverables"
+    chmod 777 "./repos/$REPO/deliverables"
+  fi
+
   # Ensure containers are running (starts them if needed)
   ensure_containers
 


### PR DESCRIPTION
Fixes #87 

Pre-create the deliverables directory with proper permissions on the host before starting containers, and surface permission errors instead of silently swallowing them in save_deliverable.