### PR TITLE
fix: install Claude Code CLI globally for Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,9 @@ RUN npm ci && \
     cd mcp-server && npm ci && cd .. && \
     npm cache clean --force
 
+# Install Claude Code CLI globally (required by claude-agent-sdk)
+RUN npm install -g @anthropic-ai/claude-code
+
 # Copy application source code
 COPY . .
 


### PR DESCRIPTION
## Problem
Shannon security tests were blocked due to missing `claude-code` binary in Docker container. Error: `spawn node ENOENT`

## Root Cause
Dockerfile included nodejs-22 but Claude Code CLI was not installed globally.

## Solution
Add `npm install -g @anthropic-ai/claude-code` to Dockerfile.

## Impact
- Unblocks Shannon security test scans
- Required by `claude-agent-sdk` for AI code execution
- Fixes Docker build failures

## Testing
- Manual verification that `@anthropic-ai/claude-code` is a standard npm package
- Ready for CI/CD validation

Closes Shannon: Run First Test Scan task