### PR TITLE
fix: resolve 'spawn node ENOENT' when SDK spawns claude CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,9 @@ RUN npm ci && \
 # Copy application source code
 COPY . .
 
+# Install Claude Code CLI (required by @anthropic-ai/claude-agent-sdk)
+RUN npm install -g @anthropic-ai/claude-code
+
 # Build TypeScript (mcp-server first, then main project)
 RUN cd mcp-server && npm run build && cd .. && npm run build
 

--- a/src/ai/claude-executor.ts
+++ b/src/ai/claude-executor.ts
@@ -220,7 +220,10 @@ export async function runClaudePrompt(
   const mcpServers = buildMcpServers(sourceDir, agentName);
 
   // Build env vars to pass to SDK subprocesses
+  // Spread process.env first so PATH and other system vars are inherited,
+  // then override with Shannon-specific vars
   const sdkEnv: Record<string, string> = {
+    ...Object.fromEntries(Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] != null)),
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS || '64000',
   };
   if (process.env.ANTHROPIC_API_KEY) {


### PR DESCRIPTION
## Problem

The Claude Agent SDK fails with `spawn node ENOENT` when attempting to run any agent inside the Docker container.

## Root Cause

Two issues:

1. **Missing CLI**: The `claude` CLI (`@anthropic-ai/claude-code`) was not installed in the Docker image. The SDK's `query()` function spawns it as a subprocess.

2. **Stripped PATH**: The `env` option passed to the SDK contained only `ANTHROPIC_API_KEY` and `CLAUDE_CODE_MAX_OUTPUT_TOKENS`. The SDK uses this as the **complete** environment for the spawned process, so `PATH` was missing and the `claude` script (`#!/usr/bin/env node`) couldn't locate `node`.

## Fix

- **Dockerfile**: Added `npm install -g @anthropic-ai/claude-code` to install the CLI.
- **claude-executor.ts**: Spread `process.env` into `sdkEnv` so `PATH` and other system variables are inherited by the spawned process.