### PR TITLE
feat: add MSYS path fix, Claude Code CLI, and Windows instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,8 @@ RUN cd mcp-server && npm run build && cd .. && npm run build
 RUN npm prune --production && \
     cd mcp-server && npm prune --production
 
+RUN npm install -g @anthropic-ai/claude-code
+
 # Create directories for session data and ensure proper permissions
 RUN mkdir -p /app/sessions /app/deliverables /app/repos /app/configs && \
     mkdir -p /tmp/.cache /tmp/.config /tmp/.npm && \

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ git clone https://github.com/your-org/api.git
 
 ### Platform-Specific Instructions
 
+**For Windows:**
+
+Install [Git for Windows](https://git-scm.com/install/windows) and run Shannon from **Git Bash** with Docker Desktop installed.
+
 **For Linux (Native Docker):**
 
 You may need to run commands with `sudo` depending on your Docker setup. If you encounter permission issues with output files, ensure your user has access to the Docker socket.

--- a/shannon
+++ b/shannon
@@ -3,6 +3,11 @@
 
 set -e
 
+# Prevent MSYS from converting Unix paths (e.g. /repos/my-repo) to Windows paths
+case "$OSTYPE" in
+  msys*) export MSYS_NO_PATHCONV=1 ;;
+esac
+
 # Detect Podman vs Docker and set compose files accordingly
 # Podman doesn't support host-gateway, so we only include the Docker override for actual Docker
 COMPOSE_BASE="docker-compose.yml"


### PR DESCRIPTION
Fixes #114 

- Prevent MSYS from converting Unix container paths on Windows
- Install @anthropic-ai/claude-code globally in the Docker image
- Add Windows platform instructions to README