### PR TITLE
fix: pass router env vars to SDK subprocess

### DIFF
--- a/src/ai/claude-executor.ts
+++ b/src/ai/claude-executor.ts
@@ -231,6 +231,12 @@ export async function runClaudePrompt(
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
     sdkEnv.CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
   }
+  if (process.env.ANTHROPIC_BASE_URL) {
+    sdkEnv.ANTHROPIC_BASE_URL = process.env.ANTHROPIC_BASE_URL;
+  }
+  if (process.env.ANTHROPIC_AUTH_TOKEN) {
+    sdkEnv.ANTHROPIC_AUTH_TOKEN = process.env.ANTHROPIC_AUTH_TOKEN;
+  }
 
   // 5. Configure SDK options
   const options = {


### PR DESCRIPTION
Closes #148
Closes #150

## Summary

- Forward `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` to the SDK subprocess environment in `claude-executor.ts`
- Without these, router mode fails with "Authentication failed: Invalid API key" because the subprocess hits Anthropic directly with the placeholder key instead of routing through claude-code-router