### PR TITLE
feat: add AWS Bedrock support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,15 @@ ANTHROPIC_API_KEY=your-api-key-here
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini
 # OpenRouter: google/gemini-3-flash-preview
+
+# =============================================================================
+# OPTION 3: AWS Bedrock
+# =============================================================================
+#
+# CLAUDE_CODE_USE_BEDROCK=1
+# AWS_REGION=your-region
+# AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key
+#
+# Default model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+# Override with ANTHROPIC_MODEL
+# ANTHROPIC_MODEL=us.anthropic.claude-sonnet-4-5

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Shannon is available in two editions:
   - [Usage Examples](#usage-examples)
   - [Workspaces and Resuming](#workspaces-and-resuming)
   - [Configuration (Optional)](#configuration-optional)
+  - [AWS Bedrock](#aws-bedrock)
   - [[EXPERIMENTAL - UNSUPPORTED] Router Mode (Alternative Providers)](#experimental---unsupported-router-mode-alternative-providers)
   - [Output and Results](#output-and-results)
 - [Sample Reports](#-sample-reports)
@@ -107,6 +108,7 @@ Shannon is available in two editions:
 - **AI Provider Credentials** (choose one):
   - **Anthropic API key** (recommended) - Get from [Anthropic Console](https://console.anthropic.com)
   - **Claude Code OAuth token**
+  - **AWS Bedrock** - Use Shannon via Amazon Bedrock (see [Bedrock Mode](#aws-bedrock))
   - **[EXPERIMENTAL - UNSUPPORTED] Alternative providers via Router Mode** - OpenAI or Google Gemini via OpenRouter (see [Router Mode](#experimental---unsupported-router-mode-alternative-providers))
 
 ### Quick Start
@@ -335,6 +337,26 @@ rules:
 #### TOTP Setup for 2FA
 
 If your application uses two-factor authentication, simply add the TOTP secret to your config file. The AI will automatically generate the required codes during testing.
+
+### AWS Bedrock
+
+Shannon can run through Amazon Bedrock as well. You'll need a [Bedrock API key](https://aws.amazon.com/blogs/machine-learning/accelerate-ai-development-with-amazon-bedrock-api-keys/).
+
+Add the following to your `.env`:
+
+```bash
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=your-region
+AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key
+```
+
+The default model is `us.anthropic.claude-sonnet-4-5-20250929-v1:0`. To override, add `ANTHROPIC_MODEL` to your `.env`.
+
+Then run as normal:
+
+```bash
+./shannon start URL=https://example.com REPO=repo-name
+```
 
 ### [EXPERIMENTAL - UNSUPPORTED] Router Mode (Alternative Providers)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-}  # Model name when using router (e.g., "gemini,gemini-2.5-pro")
       - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
       - CLAUDE_CODE_MAX_OUTPUT_TOKENS=${CLAUDE_CODE_MAX_OUTPUT_TOKENS:-64000}
+      # AWS Bedrock
+      - CLAUDE_CODE_USE_BEDROCK=${CLAUDE_CODE_USE_BEDROCK:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_BEARER_TOKEN_BEDROCK=${AWS_BEARER_TOKEN_BEDROCK:-}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-}
     depends_on:
       temporal:
         condition: service_healthy

--- a/shannon
+++ b/shannon
@@ -142,14 +142,18 @@ cmd_start() {
     exit 1
   fi
 
-  # Check for API key (router mode can use alternative provider API keys)
+  # Check for API key (router mode and Bedrock have their own credentials)
   if [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
-    if [ "$ROUTER" = "true" ] && { [ -n "$OPENAI_API_KEY" ] || [ -n "$OPENROUTER_API_KEY" ]; }; then
+    if [ "$CLAUDE_CODE_USE_BEDROCK" = "1" ]; then
+      # Bedrock mode — SDK handles auth via AWS credentials
+      :
+    elif [ "$ROUTER" = "true" ] && { [ -n "$OPENAI_API_KEY" ] || [ -n "$OPENROUTER_API_KEY" ]; }; then
       # Router mode with alternative provider - set a placeholder for SDK init
       export ANTHROPIC_API_KEY="router-mode"
     else
       echo "ERROR: Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in .env"
       echo "       (or use ROUTER=true with OPENAI_API_KEY or OPENROUTER_API_KEY)"
+      echo "       (or use CLAUDE_CODE_USE_BEDROCK=1 with AWS credentials)"
       exit 1
     fi
   fi

--- a/src/ai/claude-executor.ts
+++ b/src/ai/claude-executor.ts
@@ -222,25 +222,33 @@ export async function runClaudePrompt(
   const mcpServers = buildMcpServers(sourceDir, agentName, logger);
 
   // 4. Build env vars to pass to SDK subprocesses
+  const sdkEnvVars = [
+    'ANTHROPIC_API_KEY',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+    'ANTHROPIC_BASE_URL',
+    'ANTHROPIC_AUTH_TOKEN',
+    // AWS Bedrock — SDK handles routing internally
+    'CLAUDE_CODE_USE_BEDROCK',
+    'AWS_REGION',
+    'AWS_BEARER_TOKEN_BEDROCK',
+    'ANTHROPIC_MODEL',
+  ];
   const sdkEnv: Record<string, string> = {
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS || '64000',
   };
-  if (process.env.ANTHROPIC_API_KEY) {
-    sdkEnv.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-  }
-  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
-    sdkEnv.CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
-  }
-  if (process.env.ANTHROPIC_BASE_URL) {
-    sdkEnv.ANTHROPIC_BASE_URL = process.env.ANTHROPIC_BASE_URL;
-  }
-  if (process.env.ANTHROPIC_AUTH_TOKEN) {
-    sdkEnv.ANTHROPIC_AUTH_TOKEN = process.env.ANTHROPIC_AUTH_TOKEN;
+  for (const key of sdkEnvVars) {
+    if (process.env[key]) {
+      sdkEnv[key] = process.env[key];
+    }
   }
 
   // 5. Configure SDK options
+  const isBedrock = process.env.CLAUDE_CODE_USE_BEDROCK === '1';
+  const defaultModel = isBedrock
+    ? 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    : 'claude-sonnet-4-5-20250929';
   const options = {
-    model: 'claude-sonnet-4-5-20250929',
+    model: process.env.ANTHROPIC_MODEL || defaultModel,
     maxTurns: 10_000,
     cwd: sourceDir,
     permissionMode: 'bypassPermissions' as const,

--- a/src/services/preflight.ts
+++ b/src/services/preflight.ts
@@ -165,11 +165,17 @@ async function validateCredentials(
     return ok(undefined);
   }
 
-  // 2. Check that at least one credential is present
+  // 2. Bedrock mode — SDK handles auth via AWS credentials
+  if (process.env.CLAUDE_CODE_USE_BEDROCK === '1') {
+    logger.warn('Bedrock mode detected — skipping API credential validation');
+    return ok(undefined);
+  }
+
+  // 3. Check that at least one credential is present
   if (!process.env.ANTHROPIC_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
     return err(
       new PentestError(
-        'No API credentials found. Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in .env',
+        'No API credentials found. Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in .env (or use CLAUDE_CODE_USE_BEDROCK=1)',
         'config',
         false,
         {},
@@ -178,7 +184,7 @@ async function validateCredentials(
     );
   }
 
-  // 3. Validate via SDK query
+  // 4. Validate via SDK query
   const authType = process.env.CLAUDE_CODE_OAUTH_TOKEN ? 'OAuth token' : 'API key';
   logger.info(`Validating ${authType} via SDK...`);
 


### PR DESCRIPTION
Closes #153

## Summary
- Add support for routing Claude Agent SDK through Amazon Bedrock via `CLAUDE_CODE_USE_BEDROCK=1`
- Pass Bedrock env vars (`AWS_REGION`, `AWS_BEARER_TOKEN_BEDROCK`, `ANTHROPIC_MODEL`) through CLI, Docker, and SDK subprocess
- Bypass API credential checks in CLI (`shannon`) and preflight (`preflight.ts`) when Bedrock mode is enabled
- Auto-select Bedrock model ID (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`) with `ANTHROPIC_MODEL` override support