### PR TITLE
Feature/reverse engineering

### DIFF
--- a/mcp-server/src/types/deliverables.ts
+++ b/mcp-server/src/types/deliverables.ts
@@ -40,6 +40,13 @@ export enum DeliverableType {
   AUTH_EVIDENCE = 'AUTH_EVIDENCE',
   AUTHZ_EVIDENCE = 'AUTHZ_EVIDENCE',
   SSRF_EVIDENCE = 'SSRF_EVIDENCE',
+
+  // Reverse Engineering agents (Phase 6)
+  RE_BINARY_ANALYSIS = 'RE_BINARY_ANALYSIS',
+  RE_MOBILE_ANALYSIS = 'RE_MOBILE_ANALYSIS',
+  RE_FIRMWARE_ANALYSIS = 'RE_FIRMWARE_ANALYSIS',
+  RE_MALWARE_ANALYSIS = 'RE_MALWARE_ANALYSIS',
+  RE_COMPREHENSIVE_REPORT = 'RE_COMPREHENSIVE_REPORT',
 }
 
 /**
@@ -64,6 +71,13 @@ export const DELIVERABLE_FILENAMES: Record<DeliverableType, string> = {
   [DeliverableType.AUTH_EVIDENCE]: 'auth_exploitation_evidence.md',
   [DeliverableType.AUTHZ_EVIDENCE]: 'authz_exploitation_evidence.md',
   [DeliverableType.SSRF_EVIDENCE]: 'ssrf_exploitation_evidence.md',
+
+  // Reverse Engineering deliverables (Phase 6)
+  [DeliverableType.RE_BINARY_ANALYSIS]: 're_binary_analysis_deliverable.md',
+  [DeliverableType.RE_MOBILE_ANALYSIS]: 're_mobile_analysis_deliverable.md',
+  [DeliverableType.RE_FIRMWARE_ANALYSIS]: 're_firmware_analysis_deliverable.md',
+  [DeliverableType.RE_MALWARE_ANALYSIS]: 're_malware_analysis_deliverable.md',
+  [DeliverableType.RE_COMPREHENSIVE_REPORT]: 're_comprehensive_analysis_report.md',
 };
 
 /**

--- a/prompts/re-malware.txt
+++ b/prompts/re-malware.txt
@@ -33,7 +33,6 @@ The suspicious sample(s) to analyze are located in the `samples/` directory of t
 
 <rules>
 @include(shared/_re-rules.txt)
-</rules>
 
 1. **NEVER execute suspicious samples** - Static analysis only
 2. **Use Docker-isolated tools** - All analysis must run inside Shannon's Docker container

--- a/prompts/re-mobile.txt
+++ b/prompts/re-mobile.txt
@@ -35,7 +35,6 @@ The mobile app file(s) to analyze are located in the `samples/` directory of the
 
 <rules>
 @include(shared/_re-rules.txt)
-</rules>
 
 1. **NEVER install unknown apps** - Only perform static analysis
 2. **Use Docker-isolated tools** - All analysis must run inside Shannon's Docker container


### PR DESCRIPTION
## Summary

Implements **Phase 6 - Reverse Engineering** capabilities for the Shannon pentesting pipeline, addressing issue #174. This addition extends Shannon beyond web application penetration testing to support binary analysis, mobile app security, firmware analysis, and malware investigation.

## Changes Overview

### New Agents Added (5)

| Agent | Purpose | Tools |
|-------|---------|-------|
| `re-binary` | Binary executable analysis (ELF, PE, Mach-O) | Rizin, Detect It Easy, strings |
| `re-mobile` | Mobile app analysis (APK, IPA) | MobSF, JADX, apktool |
| `re-firmware` | Firmware extraction and analysis | Binwalk, firmware-mod-kit |
| `re-malware` | Static malware analysis | YARA, Detect It Easy |
| `re-report` | RE findings compilation | Report generation |

### New Files

- `prompts/re-binary.txt` — Binary analysis prompt template
- `prompts/re-mobile.txt` — Mobile app analysis prompt template
- `prompts/re-firmware.txt` — Firmware analysis prompt template
- `prompts/re-malware.txt` — Malware analysis prompt template
- `prompts/re-report.txt` — RE report compilation template
- `prompts/shared/_re-*.txt` — Shared prompt components (scope, target, rules)
- `Dockerfile.re` — Reverse engineering Docker image
- `docker-compose.re.yml` — RE tools service configuration

### Modified Files

- `src/types/agents.ts` — Added RE agents to `ALL_AGENTS`, new `REType`, `REAnalysisDecision`
- `src/session-manager.ts` — Registered 5 RE agents with mappings and validators

### Architecture

```
Phase 1: Pre-Recon → Phase 2: Recon → Phase 3: Vuln Analysis → 
Phase 4: Exploitation → Phase 5: Reporting → Phase 6: Reverse Engineering
```

- RE agents run **sequentially** (not parallel) for memory efficiency (works with 15GB RAM)
- Executes after Phase 5 Reporting completes
- Zero breaking changes — purely additive feature

## Usage

```bash
# Start RE pipeline after web pentest
./shannon start URL=<url> REPO=<repo> RE=true
```

When `RE=true`:
- Automatically builds `shannon-re-tools` Docker image
- Starts RE container for Phase 6 analysis
- Creates `samples/` directory for target files

## Deliverables

- `re_binary_analysis_deliverable.md`
- `re_mobile_analysis_deliverable.md`
- `re_firmware_analysis_deliverable.md`
- `re_malware_analysis_deliverable.md`
- `re_comprehensive_analysis_report.md`

## Use Cases

1. **IoT Security Assessment** — Analyze firmware alongside web interfaces
2. **Mobile App Audit** — Test APK/IPA and backend API simultaneously
3. **Malware Investigation** — Analyze suspicious binaries found during pentest
4. **Red Team Operations** — Comprehensive analysis of all attack surfaces
5. **Supply Chain Security** — Analyze third-party binaries and libraries

## Testing

- ✅ Follows Shannon's exact architectural patterns
- ✅ Uses existing infrastructure (Temporal, MCP, deliverable system)
- ✅ AGPL-3.0 license compliant
- ✅ ~1,716 lines across 7 files

## Related Issues

- Closes #174
