### PR TITLE
feat: accept arbitrary host paths for REPO argument

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ AI-powered penetration testing agent for defensive security analysis. Automates 
 # Setup
 cp .env.example .env && edit .env  # Set ANTHROPIC_API_KEY
 
-# Prepare repo (REPO is a folder name inside ./repos/, not an absolute path)
+# Prepare repo — either place it under ./repos/, or pass a host path directly
 git clone https://github.com/org/repo.git ./repos/my-repo
-# or symlink: ln -s /path/to/existing/repo ./repos/my-repo
 
 # Run
-./shannon start URL=<url> REPO=my-repo
+./shannon start URL=<url> REPO=my-repo                      # Folder under ./repos/
+./shannon start URL=<url> REPO=/path/to/my-repo             # Arbitrary host path
 ./shannon start URL=<url> REPO=my-repo CONFIG=./configs/my-config.yaml
 
 # Workspaces & Resume
@@ -150,7 +150,7 @@ Comments must be **timeless** — no references to this conversation, refactorin
 
 ## Troubleshooting
 
-- **"Repository not found"** — `REPO` must be a folder name inside `./repos/`, not an absolute path. Clone or symlink your repo there first: `ln -s /path/to/repo ./repos/my-repo`
+- **"Repository not found"** — `REPO` accepts a folder name under `./repos/` (e.g. `REPO=my-repo`) or any absolute/relative host path (e.g. `REPO=/home/user/my-repo`). The path must exist on the host.
 - **"Temporal not ready"** — Wait for health check or `docker compose logs temporal`
 - **Worker not processing** — Check `docker compose ps`
 - **Reset state** — `./shannon stop CLEAN=true`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - ./audit-logs:/app/audit-logs
       - ${OUTPUT_DIR:-./audit-logs}:/app/output
       - ./repos:/repos
+      - ${REPO_DIR:-./repos}:/ext-repo
       - ${BENCHMARKS_BASE:-.}:/benchmarks
     shm_size: 2gb
     ipc: host

--- a/shannon
+++ b/shannon
@@ -47,7 +47,7 @@ Usage:
   ./shannon help                          Show this help message
 
 Options for 'start':
-  REPO=<name>            Folder name under ./repos/ (e.g. REPO=repo-name)
+  REPO=<name>            Folder under ./repos/, or any host path (e.g. REPO=/path/to/repo)
   CONFIG=<path>          Configuration file (YAML)
   OUTPUT=<path>          Output directory for reports (default: ./audit-logs/)
   WORKSPACE=<name>       Named workspace (auto-resumes if exists, creates if new)
@@ -59,6 +59,7 @@ Options for 'stop':
 
 Examples:
   ./shannon start URL=https://example.com REPO=repo-name
+  ./shannon start URL=https://example.com REPO=/home/user/my-project
   ./shannon start URL=https://example.com REPO=repo-name WORKSPACE=q1-audit
   ./shannon start URL=https://example.com REPO=repo-name CONFIG=./config.yaml
   ./shannon start URL=https://example.com REPO=repo-name OUTPUT=./my-reports
@@ -155,17 +156,30 @@ cmd_start() {
   fi
 
   # Determine container path for REPO
-  # - If REPO is already a container path (/benchmarks/*, /repos/*), use as-is
+  # - If REPO is already a container path (/benchmarks/*, /repos/*, /ext-repo), use as-is
+  # - If REPO is a host path (absolute, or relative containing /), mount it at /ext-repo
   # - Otherwise, treat as a folder name under ./repos/ (mounted at /repos in container)
   case "$REPO" in
-    /benchmarks/*|/repos/*)
+    /benchmarks/*|/repos/*|/ext-repo*)
       CONTAINER_REPO="$REPO"
+      ;;
+    /*|./*|../*)
+      # Host path: resolve to absolute, export for dynamic volume mount
+      REPO_ABS="$(cd "$(dirname "$REPO")" 2>/dev/null && pwd)/$(basename "$REPO")"
+      if [ ! -d "$REPO_ABS" ]; then
+        echo "ERROR: Repository not found at $REPO"
+        exit 1
+      fi
+      export REPO_DIR="$REPO_ABS"
+      CONTAINER_REPO="/ext-repo"
+      REPO="$REPO_ABS"  # Used below for deliverables setup
       ;;
     *)
       if [ ! -d "./repos/$REPO" ]; then
         echo "ERROR: Repository not found at ./repos/$REPO"
         echo ""
-        echo "Place your target repository under the ./repos/ directory"
+        echo "Place your target repository under the ./repos/ directory,"
+        echo "or pass an absolute/relative path: REPO=/path/to/your/repo"
         exit 1
       fi
       CONTAINER_REPO="/repos/$REPO"
@@ -213,7 +227,10 @@ cmd_start() {
   chmod 777 ./audit-logs
 
   # Ensure repo deliverables directory is writable by container user (UID 1001)
-  if [ -d "./repos/$REPO" ]; then
+  if [ -n "$REPO_DIR" ] && [ -d "$REPO_DIR" ]; then
+    mkdir -p "$REPO_DIR/deliverables"
+    chmod 777 "$REPO_DIR/deliverables"
+  elif [ -d "./repos/$REPO" ]; then
     mkdir -p "./repos/$REPO/deliverables"
     chmod 777 "./repos/$REPO/deliverables"
   fi


### PR DESCRIPTION
## Summary

- **Accept arbitrary host paths for REPO** — extends the REPO argument to accept any absolute or relative path on the host machine (e.g. \`REPO=/home/user/my-project\` or \`REPO=./my-project\`), not just folder names under \`./repos/\`. This removes the friction of having to clone or symlink repos into the \`./repos/\` directory before running
- **Add dynamic volume mount for external repos** — adds a \`REPO_DIR\`-driven volume entry in docker-compose.yml (\`\${REPO_DIR:-./repos}:/ext-repo\`), following the same env-var interpolation pattern already used for OUTPUT_DIR and BENCHMARKS_BASE. The mount is resolved and exported before container startup
- **Fix deliverables directory creation** — the \`chmod 777\` setup for the deliverables folder now correctly targets the resolved host path rather than the hardcoded \`./repos/\$REPO\` path when an external repo is used