### PR TITLE
fix: security hardening — pin MCP dep, restrict env, improve error handling

### DIFF
--- a/.github/scripts/security-review-prompt.txt
+++ b/.github/scripts/security-review-prompt.txt
@@ -1,0 +1,48 @@
+You are a security reviewer analyzing upstream commits from an open-source repository before they are merged into a downstream fork. Your job is to identify security risks, supply chain threats, and regressions.
+
+## Context
+
+The diff below shows changes from the upstream repository (KeygraphHQ/shannon) that have not yet been pulled into our fork (benreceveur/shannon). We maintain local security patches and need to ensure upstream changes don't introduce vulnerabilities or conflict with our hardening.
+
+## Analysis Instructions
+
+Review the diff for the following categories:
+
+1. **Credential & Secret Handling** — hardcoded secrets, API keys, tokens, credentials in code or config
+2. **Environment Variable Leaks** — new env vars that could expose sensitive data, logging of env values
+3. **Dependency Changes** — new/updated packages in package.json, lockfile changes, known vulnerable versions
+4. **Subprocess & Command Execution** — shell exec, child_process, dynamic code execution
+5. **Path Traversal & File Access** — unsanitized file paths, directory traversal, arbitrary file read/write
+6. **Input Validation & Injection** — SQL injection, XSS, command injection, template injection, missing sanitization
+7. **Authentication & Authorization** — auth bypass, privilege escalation, session handling changes
+8. **Error Handling Regressions** — removed try/catch, swallowed errors, information leakage in error messages
+9. **Supply Chain Risks** — new external service calls, changed URLs/endpoints, new network requests
+10. **Crypto & Data Protection** — weak algorithms, removed encryption, plaintext storage of sensitive data
+
+## Output Format
+
+Start with a one-line recommendation:
+
+**Recommendation:** SAFE TO PULL | REVIEW NEEDED | BLOCK MERGE
+
+Then provide a summary:
+
+### Summary
+[2-3 sentence overview of the changes and overall risk level]
+
+### Findings
+
+| Severity | Category | File | Line(s) | Description |
+|----------|----------|------|---------|-------------|
+| CRITICAL | ... | ... | ... | ... |
+| HIGH | ... | ... | ... | ... |
+| MEDIUM | ... | ... | ... | ... |
+| LOW | ... | ... | ... | ... |
+
+If no findings: "No security issues identified."
+
+### Changed Files Summary
+[List of changed files grouped by type: source, config, dependencies, docs]
+
+### Notes for Reviewers
+[Any additional context, conflicts with known local patches, or areas needing manual review]

--- a/.github/workflows/upstream-monitor.yml
+++ b/.github/workflows/upstream-monitor.yml
@@ -1,0 +1,202 @@
+name: Upstream Security Monitor
+
+on:
+  schedule:
+    - cron: '0 8 * * *' # Daily at 8am UTC
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  monitor-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/KeygraphHQ/shannon.git || true
+          git fetch upstream main
+
+      - name: Check for new upstream commits
+        id: check
+        run: |
+          COMMIT_COUNT=$(git rev-list main..upstream/main --count)
+          echo "commit_count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "No new upstream commits. Exiting."
+            exit 0
+          fi
+
+          echo "Found $COMMIT_COUNT new upstream commit(s)."
+          git log main..upstream/main --oneline > /tmp/commit_list.txt
+          cat /tmp/commit_list.txt
+
+      - name: Check for existing open issue
+        if: steps.check.outputs.commit_count != '0'
+        id: dedup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "upstream-update" --state open --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Open upstream-update issue already exists. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate diff and context
+        if: steps.check.outputs.commit_count != '0' && steps.dedup.outputs.skip != 'true'
+        run: |
+          # Generate the diff
+          git diff main...upstream/main > /tmp/upstream_diff.txt
+
+          # Check diff size (100KB guard)
+          DIFF_SIZE=$(wc -c < /tmp/upstream_diff.txt)
+          echo "Diff size: $DIFF_SIZE bytes"
+
+          if [ "$DIFF_SIZE" -gt 102400 ]; then
+            echo "Warning: Diff exceeds 100KB ($DIFF_SIZE bytes). Truncating." > /tmp/diff_note.txt
+            head -c 102400 /tmp/upstream_diff.txt > /tmp/upstream_diff_truncated.txt
+            echo -e "\n\n[TRUNCATED — original diff was $DIFF_SIZE bytes]" >> /tmp/upstream_diff_truncated.txt
+            mv /tmp/upstream_diff_truncated.txt /tmp/upstream_diff.txt
+          else
+            echo "" > /tmp/diff_note.txt
+          fi
+
+          # Changed files list
+          git diff main...upstream/main --name-status > /tmp/changed_files.txt
+
+          # Dependency changes
+          git diff main...upstream/main -- '**/package.json' > /tmp/dep_changes.txt 2>/dev/null || echo "No package.json changes" > /tmp/dep_changes.txt
+
+          # Env changes
+          git diff main...upstream/main -- '**/.env*' '**/env*' > /tmp/env_changes.txt 2>/dev/null || echo "No env file changes" > /tmp/env_changes.txt
+
+      - name: Call Claude API for security review
+        if: steps.check.outputs.commit_count != '0' && steps.dedup.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          PROMPT=$(cat .github/scripts/security-review-prompt.txt)
+          COMMIT_LIST=$(cat /tmp/commit_list.txt)
+          CHANGED_FILES=$(cat /tmp/changed_files.txt)
+          DEP_CHANGES=$(cat /tmp/dep_changes.txt)
+          ENV_CHANGES=$(cat /tmp/env_changes.txt)
+          DIFF=$(cat /tmp/upstream_diff.txt)
+          DIFF_NOTE=$(cat /tmp/diff_note.txt)
+
+          # Build the user message with all context
+          USER_MSG=$(cat <<ENDMSG
+          ## Upstream Commits ($(cat /tmp/commit_list.txt | wc -l | tr -d ' ') new)
+
+          $COMMIT_LIST
+
+          ## Changed Files
+
+          $CHANGED_FILES
+
+          ## Dependency Changes
+
+          $DEP_CHANGES
+
+          ## Environment File Changes
+
+          $ENV_CHANGES
+
+          $DIFF_NOTE
+
+          ## Full Diff
+
+          \`\`\`diff
+          $DIFF
+          \`\`\`
+          ENDMSG
+          )
+
+          # Call Claude API
+          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "content-type: application/json" \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -d "$(jq -n \
+              --arg system "$PROMPT" \
+              --arg user_msg "$USER_MSG" \
+              '{
+                model: "claude-sonnet-4-6",
+                max_tokens: 4096,
+                system: $system,
+                messages: [
+                  { role: "user", content: $user_msg }
+                ]
+              }')")
+
+          # Extract the text response
+          echo "$RESPONSE" | jq -r '.content[0].text' > /tmp/security_review.txt
+
+          # Check for API errors
+          if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+            echo "Claude API error:"
+            echo "$RESPONSE" | jq '.error'
+            exit 1
+          fi
+
+      - name: Create GitHub issue
+        if: steps.check.outputs.commit_count != '0' && steps.dedup.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_COUNT: ${{ steps.check.outputs.commit_count }}
+        run: |
+          REVIEW=$(cat /tmp/security_review.txt)
+          COMMIT_LIST=$(cat /tmp/commit_list.txt)
+          CHANGED_FILES=$(cat /tmp/changed_files.txt)
+
+          ISSUE_BODY=$(cat <<'HEADER'
+          ## Upstream Security Review
+
+          **Upstream:** `KeygraphHQ/shannon`
+          **Fork:** `benreceveur/shannon`
+          HEADER
+          )
+
+          ISSUE_BODY+="
+          **New commits:** $COMMIT_COUNT
+
+          ---
+
+          $REVIEW
+
+          ---
+
+          <details>
+          <summary>Commit List ($COMMIT_COUNT commits)</summary>
+
+          \`\`\`
+          $COMMIT_LIST
+          \`\`\`
+
+          </details>
+
+          <details>
+          <summary>Changed Files</summary>
+
+          \`\`\`
+          $CHANGED_FILES
+          \`\`\`
+
+          </details>
+
+          ---
+          *Generated by upstream-monitor workflow — $(date -u +%Y-%m-%d)*"
+
+          gh issue create \
+            --title "Upstream Review: $COMMIT_COUNT new commits from KeygraphHQ/shannon" \
+            --body "$ISSUE_BODY" \
+            --label "upstream-update,security-review"


### PR DESCRIPTION
## Summary

Security review identified 11 findings (2 CRITICAL, 3 HIGH, 6 MEDIUM). This PR addresses all of them.

### CRITICAL fixes
- **Pin `@playwright/mcp` to `0.0.68`** instead of `@latest` — prevents supply chain attacks via unpinned runtime `npx` fetch
- **Restrict MCP subprocess env to allowlist** (`PATH`, `HOME`, `NODE_PATH`, Playwright-specific vars) — previously `...process.env` leaked all credentials (`ANTHROPIC_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, `CLAUDE_CODE_OAUTH_TOKEN`, etc.) to the Playwright MCP subprocess

### HIGH fixes
- **Workspace name validation** in `terminateExistingWorkflows` and `loadResumeState` (defense-in-depth — regex exists but wasn't applied in all code paths)
- **Propagate `assembleReportActivity` errors** — report is the primary deliverable; silently swallowing assembly failures caused "success" status with broken reports
- **Log Bedrock/Vertex credential validation** as presence-only warning (validity isn't checked until first agent run, unlike direct API keys which get an SDK round-trip)

### MEDIUM fixes
- **Default unknown errors to non-retryable** in `classifyErrorForTemporal` — previously unknown errors defaulted to `retryable: true`, causing up to 50 retries with 5-30min backoff on novel permanent errors
- **Differentiate ENOENT from corruption** in workspace listing — previously all errors were silently skipped
- **Add visible warnings** for: progress polling failures (after 3 consecutive), config parse errors, cumulative cost display failures, error log write failures

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Run pipeline with direct API key — preflight should validate via SDK query as before
- [ ] Run pipeline with Bedrock/Vertex credentials — preflight should warn about presence-only validation
- [ ] Test workspace resume flow — workspace name validation should reject invalid names
- [ ] Verify Playwright MCP subprocess no longer receives API keys (check via `ps eww` or env inspection)
- [ ] Trigger a report assembly failure — workflow should now fail instead of reporting success

🤖 Generated with [Claude Code](https://claude.com/claude-code)