### PR TITLE
Fix config schema permission error on Linux Docker

### DIFF
--- a/shannon
+++ b/shannon
@@ -246,9 +246,11 @@ cmd_start() {
     export ANTHROPIC_AUTH_TOKEN="shannon-router-key"
   fi
 
-  # Ensure audit-logs directory exists with write permissions for container user (UID 1001)
+  # Ensure host-mounted directories are readable by container user (UID 1001)
+  # On Linux, bind mounts preserve host permissions — configs may be root-owned
   mkdir -p ./audit-logs ./credentials
   chmod 777 ./audit-logs
+  chmod -R a+r ./configs 2>/dev/null || true
 
   # Ensure repo deliverables directory is writable by container user (UID 1001)
   if [ -d "./repos/$REPO" ]; then


### PR DESCRIPTION
## Summary

Fixes `EACCES: permission denied, open '/app/configs/config-schema.json'` on Linux Docker hosts.

## Root Cause

On Linux, Docker bind mounts preserve host filesystem permissions verbatim. The `./configs:/app/configs` volume mount in `docker-compose.yml` replaces the image's properly-owned `/app/configs` (owned by `pentest:pentest`, UID 1001) with the host's `./configs/` directory, which is typically owned by `root:root`. The container's non-root `pentest` user cannot read root-owned files.

This works on macOS because Docker Desktop's file-sharing layer (VirtioFS/gRPC FUSE) transparently handles permission translation.

## Fix

Add `chmod -R a+r ./configs` in the `shannon` CLI script before starting containers. This follows the same permission-fixing pattern already used for `audit-logs` (`chmod 777 ./audit-logs`) and `deliverables` directories.

## Test plan

- [ ] Verify on Linux Docker: `./shannon start URL=... REPO=...` no longer fails with EACCES
- [ ] Verify on macOS Docker: no regression (chmod is a no-op when already readable)
- [ ] Verify `|| true` suppresses errors when `./configs/` doesn't exist yet

Closes #197

🤖 Generated with [ClosedLoop](https://closedloop.sh)