### PR TITLE
Add CODEOWNERS for branch protection reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @closedloop-ai/engineering


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` assigning `@closedloop-ai/engineering` as default code owners for all files.

## What this enables

- Required review approvals from the engineering team via GitHub branch protection rules
- Automatic review requests when PRs are opened

🤖 Generated with [ClosedLoop](https://closedloop.sh)