### PR TITLE
fix: propagate focus rules to vuln/exploit agents

### DIFF
--- a/prompts/shared/_rules.txt
+++ b/prompts/shared/_rules.txt
@@ -1,2 +1,5 @@
 Rules to Avoid:
 {{RULES_AVOID}}
+
+Rules to Focus:
+{{RULES_FOCUS}}


### PR DESCRIPTION
## Summary

- Add `{{RULES_FOCUS}}` placeholder to `prompts/shared/_rules.txt` so user-configured focus rules reach all 10 vuln-* and exploit-* agents
- Currently only the `recon` agent receives focus rules (which has `{{RULES_FOCUS}}` inline); all other agents include `shared/_rules.txt` which was missing the placeholder

## Root cause

`prompt-manager.ts` L177-178 correctly replaces `{{RULES_FOCUS}}`, but the replacement is a no-op for the 10 templates that `@include(shared/_rules.txt)` because the shared partial only contained `{{RULES_AVOID}}`.

## Change

```diff
 Rules to Avoid:
 {{RULES_AVOID}}
+
+Rules to Focus:
+{{RULES_FOCUS}}
```

One file, two lines.

Fixes #240