### PR TITLE
fix: resolve Node.js v24 type error in config schema loading

### DIFF
--- a/apps/worker/src/config-parser.ts
+++ b/apps/worker/src/config-parser.ts
@@ -5,6 +5,7 @@
 // as published by the Free Software Foundation.
 
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { Ajv, type ErrorObject, type ValidateFunction } from 'ajv';
 import type { FormatsPlugin } from 'ajv-formats';
 import yaml from 'js-yaml';
@@ -25,7 +26,7 @@ let validateSchema: ValidateFunction;
 
 try {
   const schemaPath = new URL('../configs/config-schema.json', import.meta.url);
-  const schemaContent = await fs.readFile(schemaPath, 'utf8');
+  const schemaContent = await fs.readFile(fileURLToPath(schemaPath), 'utf8');
   configSchema = JSON.parse(schemaContent) as object;
   validateSchema = ajv.compile(configSchema);
 } catch (error) {


### PR DESCRIPTION
## Summary
- Convert `URL` to file path string via `fileURLToPath()` before passing to `fs.readFile()` in `config-parser.ts`
- Fixes `TS2769` compilation error with stricter `@types/node` in Node.js v24, where `URL` is no longer assignable to `fs.readFile()`'s `file` parameter

## Test plan
- [x] `pnpm run build` succeeds on Node.js v24
- [ ] Verify build still works on Node.js v20/v22