### PR TITLE
chore: enforce pnpm minimum release age and upgrade to v10.33.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 auto-install-peers=true
 strict-peer-dependencies=false
+minimum-release-age=10080
+ignore-scripts=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,10 @@ Comments must be **timeless** — no references to this conversation, refactorin
 
 **CI/CD:** `.github/workflows/release.yml` (Docker Hub push + npm publish + GitHub release, manual dispatch)
 
+## Package Installation
+
+Package managers are configured with a minimum release age (7 days). Requires pnpm >= 10.16.0. If `pnpm install` fails due to a package being too new, **do not attempt to bypass it** — report the blocked package to the user and stop.
+
 ## Troubleshooting
 
 - **"Repository not found"** — Pass a bare name (`-r my-repo`) for `./repos/my-repo`, or a path (`-r /path/to/repo`) for any directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN curl -sL https://github.com/urbanadventurer/WhatWeb/archive/refs/tags/v0.6.3
 RUN pip3 install --no-cache-dir schemathesis==4.13.0
 
 # Install pnpm
-RUN npm install -g pnpm@10.12.1
+RUN npm install -g pnpm@10.33.0
 
 # Build Node.js application in builder to avoid QEMU emulation failures in CI
 WORKDIR /app
@@ -69,7 +69,8 @@ COPY . .
 # Build worker. CLI not needed in Docker
 RUN pnpm --filter @shannon/worker run build
 
-RUN pnpm prune --prod
+# Production-only deps (pnpm recommends install --prod over prune in monorepos)
+RUN rm -rf node_modules apps/*/node_modules && pnpm install --frozen-lockfile --prod
 
 # Runtime stage - Minimal production image
 FROM cgr.dev/chainguard/wolfi-base:latest AS runtime

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "turbo run build",
     "check": "turbo run check",


### PR DESCRIPTION
- Add minimum-release-age=10080 (7 days) and ignore-scripts=true to .npmrc
- Upgrade pnpm from 10.12.1 to 10.33.0 (minimumReleaseAge requires >= 10.16.0)
- Document package installation age policy in CLAUDE.md