### PR TITLE
feat: use structured outputs for vuln agent exploitation queues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -50,6 +50,7 @@ Thumbs.db
 # Keep apps/cli/package.json so pnpm workspaces resolve
 apps/cli/src/
 apps/cli/dist/
+apps/worker/dist/
 apps/cli/infra/
 apps/cli/tsconfig.json
 apps/cli/tsdown.config.ts

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,6 +18,7 @@
     "ajv-formats": "^2.1.1",
     "dotenv": "^16.4.5",
     "js-yaml": "^4.1.0",
+    "zod": "^4.3.6",
     "zx": "^8.0.0"
   },
   "devDependencies": {

--- a/apps/worker/prompts/exploit-auth.txt
+++ b/apps/worker/prompts/exploit-auth.txt
@@ -144,10 +144,10 @@ You are the **Identity Compromise Specialist** - proving tangible impact of brok
 <cli_tools>
 - **Browser Automation (playwright-cli skill):** Essential for interacting with multi-step authentication flows, injecting stolen session cookies, and verifying account takeover in a real browser context. Invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for brute force batches, credential stuffing, token replay automation, and any scripted workflow.
 - **TodoWrite tool:** Essential for managing your exploitation task list. You MUST use this tool to track all tasks, mark progress, and document your exploitation workflow.

--- a/apps/worker/prompts/exploit-authz.txt
+++ b/apps/worker/prompts/exploit-authz.txt
@@ -131,10 +131,10 @@ You are the **Privilege Escalation Specialist** - proving tangible impact of bro
 <cli_tools>
 - **Browser Automation (playwright-cli skill):** Essential for interacting with complex authorization flows, testing role-based access controls in browser contexts, and verifying privilege escalation through UI elements. Invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for IDOR sweeps, role escalation loops, and workflow bypass automation.
 - **TodoWrite tool:** Essential for managing your exploitation task list. You MUST use this tool to track all tasks, mark progress, and document your exploitation workflow.

--- a/apps/worker/prompts/exploit-injection.txt
+++ b/apps/worker/prompts/exploit-injection.txt
@@ -113,10 +113,10 @@ You are the **Proof-of-Impact Generator** - converting theoretical injection fla
 <cli_tools>
 - **Browser Automation (playwright-cli skill):** For testing injection vulnerabilities through browser interactions when needed. Invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for any custom scripting beyond single ad-hoc commands.
 - **TodoWrite tool:** Essential for managing your exploitation task list. You MUST use this tool to track all tasks, mark progress, and document your exploitation workflow.

--- a/apps/worker/prompts/exploit-ssrf.txt
+++ b/apps/worker/prompts/exploit-ssrf.txt
@@ -130,10 +130,10 @@ You are the **Network Boundary Breaker** - proving tangible impact of SSRF vulne
 
 <cli_tools>
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Browser Automation (playwright-cli skill):** Useful for complex multi-step SSRF exploitation that requires browser context or JavaScript execution. Invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **Task Agent:** Mandatory coder-executor for host enumeration loops, protocol sweeps, and metadata retrieval scripts.

--- a/apps/worker/prompts/exploit-xss.txt
+++ b/apps/worker/prompts/exploit-xss.txt
@@ -133,10 +133,10 @@ You are the **Client-Side Impact Demonstrator** - converting theoretical XSS fla
 <cli_tools>
 - **Browser Automation (playwright-cli skill):** Your primary tool for testing DOM-based and Stored XSS, confirming script execution in a real browser context, and interacting with the application post-exploitation. Invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Task Agent:** Mandatory coder-executor for payload iteration scripts, exfiltration listeners, and DOM interaction helpers beyond single manual steps.
 - **TodoWrite tool:** To create and manage your exploitation todo list, tracking each vulnerability systematically.

--- a/apps/worker/prompts/pipeline-testing/vuln-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-auth.txt
@@ -8,5 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type AUTH_ANALYSIS --content '# Auth Analysis Report\n\nAnalysis complete. No authentication vulnerabilities identified.'`
 
-3. Save a queue deliverable:
-   - Run: `save-deliverable --type AUTH_QUEUE --content '{"vulnerabilities": []}'`
+3. Your final response must be exactly: {"vulnerabilities": []}

--- a/apps/worker/prompts/pipeline-testing/vuln-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-auth.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type AUTH_ANALYSIS --content '# Auth Analysis Report\n\nAnalysis complete. No authentication vulnerabilities identified.'`
 
-As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.
+As a final step, return an empty array for vulnerabilities.

--- a/apps/worker/prompts/pipeline-testing/vuln-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-auth.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type AUTH_ANALYSIS --content '# Auth Analysis Report\n\nAnalysis complete. No authentication vulnerabilities identified.'`
 
-3. Your final response must be exactly: {"vulnerabilities": []}
+As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.

--- a/apps/worker/prompts/pipeline-testing/vuln-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-authz.txt
@@ -8,5 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type AUTHZ_ANALYSIS --content '# Authorization Analysis Report\n\nAnalysis complete. No authorization vulnerabilities identified.'`
 
-3. Save a queue deliverable:
-   - Run: `save-deliverable --type AUTHZ_QUEUE --content '{"vulnerabilities": []}'`
+3. Your final response must be exactly: {"vulnerabilities": []}

--- a/apps/worker/prompts/pipeline-testing/vuln-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-authz.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type AUTHZ_ANALYSIS --content '# Authorization Analysis Report\n\nAnalysis complete. No authorization vulnerabilities identified.'`
 
-3. Your final response must be exactly: {"vulnerabilities": []}
+As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.

--- a/apps/worker/prompts/pipeline-testing/vuln-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-authz.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type AUTHZ_ANALYSIS --content '# Authorization Analysis Report\n\nAnalysis complete. No authorization vulnerabilities identified.'`
 
-As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.
+As a final step, return an empty array for vulnerabilities.

--- a/apps/worker/prompts/pipeline-testing/vuln-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-injection.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type INJECTION_ANALYSIS --content '# Injection Analysis Report\n\nAnalysis complete. No injection vulnerabilities identified.'`
 
-3. Your final response must be exactly: {"vulnerabilities": []}
+As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.

--- a/apps/worker/prompts/pipeline-testing/vuln-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-injection.txt
@@ -8,5 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type INJECTION_ANALYSIS --content '# Injection Analysis Report\n\nAnalysis complete. No injection vulnerabilities identified.'`
 
-3. Save a queue deliverable:
-   - Run: `save-deliverable --type INJECTION_QUEUE --content '{"vulnerabilities": []}'`
+3. Your final response must be exactly: {"vulnerabilities": []}

--- a/apps/worker/prompts/pipeline-testing/vuln-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-injection.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type INJECTION_ANALYSIS --content '# Injection Analysis Report\n\nAnalysis complete. No injection vulnerabilities identified.'`
 
-As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.
+As a final step, return an empty array for vulnerabilities.

--- a/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type SSRF_ANALYSIS --content '# SSRF Analysis Report\n\nAnalysis complete. No SSRF vulnerabilities identified.'`
 
-3. Your final response must be exactly: {"vulnerabilities": []}
+As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.

--- a/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type SSRF_ANALYSIS --content '# SSRF Analysis Report\n\nAnalysis complete. No SSRF vulnerabilities identified.'`
 
-As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.
+As a final step, return an empty array for vulnerabilities.

--- a/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
@@ -8,5 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type SSRF_ANALYSIS --content '# SSRF Analysis Report\n\nAnalysis complete. No SSRF vulnerabilities identified.'`
 
-3. Save a queue deliverable:
-   - Run: `save-deliverable --type SSRF_QUEUE --content '{"vulnerabilities": []}'`
+3. Your final response must be exactly: {"vulnerabilities": []}

--- a/apps/worker/prompts/pipeline-testing/vuln-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-xss.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type XSS_ANALYSIS --content '# XSS Analysis Report\n\nAnalysis complete. No XSS vulnerabilities identified.'`
 
-3. Your final response must be exactly: {"vulnerabilities": []}
+As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.

--- a/apps/worker/prompts/pipeline-testing/vuln-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-xss.txt
@@ -8,5 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type XSS_ANALYSIS --content '# XSS Analysis Report\n\nAnalysis complete. No XSS vulnerabilities identified.'`
 
-3. Save a queue deliverable:
-   - Run: `save-deliverable --type XSS_QUEUE --content '{"vulnerabilities": []}'`
+3. Your final response must be exactly: {"vulnerabilities": []}

--- a/apps/worker/prompts/pipeline-testing/vuln-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-xss.txt
@@ -8,4 +8,4 @@ Please complete these tasks using your CLI tools:
 2. Save an analysis deliverable:
    - Run: `save-deliverable --type XSS_ANALYSIS --content '# XSS Analysis Report\n\nAnalysis complete. No XSS vulnerabilities identified.'`
 
-As a final step, return an empty array for vulnerabilities using structured output as this is primarily for pipeline testing.
+As a final step, return an empty array for vulnerabilities.

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -84,10 +84,10 @@ You are the **Code Intelligence Gatherer** and **Architectural Foundation Builde
 - **Task Agent (Code Analysis):** Your primary tool. Use it to ask targeted questions about the source code, trace authentication mechanisms, map attack surfaces, and understand architectural patterns. MANDATORY for all source code analysis.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create todo items for each phase and agent that needs execution. Mark items as "in_progress" when working on them and "completed" when done.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 </cli_tools>
 

--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -61,10 +61,10 @@ Please use these tools for the following use cases:
 - Task tool: **MANDATORY for ALL source code analysis.** You MUST delegate all code reading, searching, and analysis to Task agents. DO NOT use Read, Glob, or Grep tools for source code.
 - **Browser Automation (playwright-cli skill):** For all browser interactions, invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 
 **CRITICAL TASK AGENT RULE:** You are PROHIBITED from using Read, Glob, or Grep tools for source code analysis. All code examination must be delegated to Task agents for deeper, more thorough analysis.

--- a/apps/worker/prompts/vuln-auth.txt
+++ b/apps/worker/prompts/vuln-auth.txt
@@ -78,10 +78,10 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 **Available Tools:**
 - **Task Agent (Code Analysis):** Your primary tool. Use it to ask targeted questions about the source code, trace authentication logic paths, and understand session/credential handling. MANDATORY for all source code analysis.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Browser Automation (playwright-cli skill):** For browser interactions with the live web application (multi-step flows like password reset or registration), invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each endpoint/flow that needs analysis. Mark items as "in_progress" when working on them and "completed" when done.

--- a/apps/worker/prompts/vuln-auth.txt
+++ b/apps/worker/prompts/vuln-auth.txt
@@ -257,7 +257,7 @@ This file serves as the handoff mechanism and must always be created to signal c
       3. Repeat step 2 for all remaining sections
       4. Run `save-deliverable` with `--type AUTH_ANALYSIS --file-path "deliverables/auth_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-    - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+    - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**AUTH ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-auth.txt
+++ b/apps/worker/prompts/vuln-auth.txt
@@ -42,7 +42,7 @@ Success criterion: A complete, code-backed analysis of every potential authentic
 **Phase Sequence:** RECON (Complete) → **AUTH ANALYSIS (You)** → EXPLOITATION (next phase)
 
 **Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/auth_exploitation_queue.json` (actionable vulnerabilities for exploitation)
+**Your Output:** `deliverables/auth_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, endpoints, and data flows
@@ -237,27 +237,20 @@ These components were analyzed and found to have robust defenses. They are low-p
 
 </deliverable_instructions>
 
-<exploitation_queue_requirements>
-**Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
-- **If vulnerabilities found:** Your final response will be automatically captured as the exploitation queue JSON with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-- **If no vulnerabilities found:** Your final response must be `{"vulnerabilities": []}`.
-- **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
-This file serves as the handoff mechanism and must always be created to signal completion.
-</exploitation_queue_requirements>
 
 <conclusion_trigger>
 **COMPLETION REQUIREMENTS (ALL must be satisfied):**
 
 1.  **Systematic Analysis:** ALL relevant API endpoints and user-facing features identified in the reconnaissance deliverable must be analyzed for AuthN/AuthZ flaws.
-2.  **Deliverable Generation:** Both required deliverables must be successfully saved using the save-deliverable CLI tool:
+2.  **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
     - **CHUNKED WRITING (MANDATORY):**
       1. Use the **Write** tool to create `deliverables/auth_analysis_deliverable.md` with the title and first major section
       2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
       3. Repeat step 2 for all remaining sections
       4. Run `save-deliverable` with `--type AUTH_ANALYSIS --file-path "deliverables/auth_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-    - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+
+**Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**AUTH ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-auth.txt
+++ b/apps/worker/prompts/vuln-auth.txt
@@ -90,7 +90,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 <data_format_specifications>
 
 <exploitation_queue_format>
-**Purpose:** Defines the structure for a "exploitation queue" saved via the save-deliverable CLI with --type AUTH_QUEUE.
+**Purpose:** Defines the structure of the agent's final structured response for the exploitation queue.
 **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability json (AUTH-VULN-XX)",
@@ -181,7 +181,7 @@ Rule: when uncertain, round down (favor Medium/Low) to minimize false positives.
 # Documenting Findings (MANDATORY)
 For each check you perform from the list above (Transport, Rate Limiting, Session Management, etc.), you must make a final **verdict**.
 
-- If the verdict is **`vulnerable`**, you must document the finding using the save-deliverable CLI to update the exploitation queue.
+- If the verdict is **`vulnerable`**, you must include the finding in your final structured response's exploitation queue.
 - If the verdict is **`safe`**, you **MUST NOT** add the finding to the exploitation queue. These secure components should be documented in the "Secure by Design: Validated Components" section of your final Markdown report.
 </methodology>
 
@@ -239,9 +239,9 @@ These components were analyzed and found to have robust defenses. They are low-p
 
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST create the exploitation queue using the save-deliverable CLI tool:
-- **If vulnerabilities found:** Run save-deliverable CLI with `--type AUTH_QUEUE --content '{"vulnerabilities": [...]}'` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-- **If no vulnerabilities found:** Run save-deliverable CLI with `--type AUTH_QUEUE --content '{"vulnerabilities": []}'`.
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as your final structured response:
+- **If vulnerabilities found:** Your final response will be automatically captured as the exploitation queue JSON with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
+- **If no vulnerabilities found:** Your final response must be `{"vulnerabilities": []}`.
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
 This file serves as the handoff mechanism and must always be created to signal completion.
 </exploitation_queue_requirements>
@@ -257,7 +257,7 @@ This file serves as the handoff mechanism and must always be created to signal c
       3. Repeat step 2 for all remaining sections
       4. Run `save-deliverable` with `--type AUTH_ANALYSIS --file-path "deliverables/auth_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-    - Exploitation queue: Run save-deliverable CLI with `--type AUTH_QUEUE --content '{"vulnerabilities": [...]}'`
+    - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**AUTH ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-auth.txt
+++ b/apps/worker/prompts/vuln-auth.txt
@@ -90,7 +90,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 <data_format_specifications>
 
 <exploitation_queue_format>
-**Purpose:** Defines the structure of the agent's final structured response for the exploitation queue.
+**Purpose:** Defines the format of the exploitation queue JSON.
 **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability json (AUTH-VULN-XX)",
@@ -181,7 +181,7 @@ Rule: when uncertain, round down (favor Medium/Low) to minimize false positives.
 # Documenting Findings (MANDATORY)
 For each check you perform from the list above (Transport, Rate Limiting, Session Management, etc.), you must make a final **verdict**.
 
-- If the verdict is **`vulnerable`**, you must include the finding in your final structured response's exploitation queue.
+- If the verdict is **`vulnerable`**, you must include the finding in your exploitation queue.
 - If the verdict is **`safe`**, you **MUST NOT** add the finding to the exploitation queue. These secure components should be documented in the "Secure by Design: Validated Components" section of your final Markdown report.
 </methodology>
 
@@ -239,7 +239,7 @@ These components were analyzed and found to have robust defenses. They are low-p
 
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as your final structured response:
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
 - **If vulnerabilities found:** Your final response will be automatically captured as the exploitation queue JSON with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
 - **If no vulnerabilities found:** Your final response must be `{"vulnerabilities": []}`.
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.

--- a/apps/worker/prompts/vuln-authz.txt
+++ b/apps/worker/prompts/vuln-authz.txt
@@ -93,7 +93,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 <data_format_specifications>
 
 <exploitation_queue_format>
-**Purpose:** Defines the structure of the agent's final structured response.
+**Purpose:** Defines the format of the exploitation queue JSON.
 **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability (e.g., AUTHZ-VULN-01)",
@@ -238,7 +238,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 
 For each analysis you perform from the lists above, you must make a final **verdict**:
 
-- If the verdict is **`vulnerable`**, you must include the finding in your final structured response's exploitation queue.
+- If the verdict is **`vulnerable`**, you must include the finding in your exploitation queue.
 - If the verdict is **`safe`**, you **MUST NOT** add the finding to the exploitation queue. These secure components should be documented in the "Secure by Design: Validated Components" section of your final Markdown report.
 </methodology>
 
@@ -342,7 +342,7 @@ examples:
 
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as structured output:
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
 - **If vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": [...]}` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
 - **If no vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": []}`.
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.

--- a/apps/worker/prompts/vuln-authz.txt
+++ b/apps/worker/prompts/vuln-authz.txt
@@ -45,7 +45,7 @@ Success criterion: A complete, code-backed analysis of every potential authoriza
 **Phase Sequence:** RECON (Complete) → **AUTHZ ANALYSIS (You)** → EXPLOITATION (next phase)
 
 **Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/authz_exploitation_queue.json` (actionable vulnerabilities for exploitation)
+**Your Output:** `deliverables/authz_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, endpoints, and data flows
@@ -340,27 +340,20 @@ examples:
 
 </deliverable_instructions>
 
-<exploitation_queue_requirements>
-**Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
-- **If vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": [...]}` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-- **If no vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": []}`.
-- **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
-This file serves as the handoff mechanism and must always be created to signal completion.
-</exploitation_queue_requirements>
 
 <conclusion_trigger>
 **COMPLETION REQUIREMENTS (ALL must be satisfied):**
 
 1. **Todo Completion:** ALL tasks in your TodoWrite list must be marked as "completed"
-2. **Deliverable Generation:** Both required deliverables must be successfully saved using the save-deliverable CLI tool:
+2. **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
    - **CHUNKED WRITING (MANDATORY):**
      1. Use the **Write** tool to create `deliverables/authz_analysis_deliverable.md` with the title and first major section
      2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type AUTHZ_ANALYSIS --file-path "deliverables/authz_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+
+**Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**AUTHORIZATION ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-authz.txt
+++ b/apps/worker/prompts/vuln-authz.txt
@@ -360,7 +360,7 @@ This file serves as the handoff mechanism and must always be created to signal c
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type AUTHZ_ANALYSIS --file-path "deliverables/authz_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+   - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**AUTHORIZATION ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-authz.txt
+++ b/apps/worker/prompts/vuln-authz.txt
@@ -81,10 +81,10 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 **Available Tools:**
 - **Task Agent (Code Analysis):** Your primary tool. Use it to ask targeted questions about the source code, trace authorization logic paths, and understand permission models. MANDATORY for all source code analysis.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Browser Automation (playwright-cli skill):** For browser interactions with the live web application (multi-step flows and role-based access controls), invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each endpoint that needs authorization analysis. Mark items as "in_progress" when working on them and "completed" when done.

--- a/apps/worker/prompts/vuln-authz.txt
+++ b/apps/worker/prompts/vuln-authz.txt
@@ -93,7 +93,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 <data_format_specifications>
 
 <exploitation_queue_format>
-**Purpose:** Defines the structure for a "exploitation queue" saved via the save-deliverable CLI with --type AUTHZ_QUEUE.
+**Purpose:** Defines the structure of the agent's final structured response.
 **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability (e.g., AUTHZ-VULN-01)",
@@ -238,7 +238,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 
 For each analysis you perform from the lists above, you must make a final **verdict**:
 
-- If the verdict is **`vulnerable`**, you must document the finding using the save-deliverable CLI to update the exploitation queue.
+- If the verdict is **`vulnerable`**, you must include the finding in your final structured response's exploitation queue.
 - If the verdict is **`safe`**, you **MUST NOT** add the finding to the exploitation queue. These secure components should be documented in the "Secure by Design: Validated Components" section of your final Markdown report.
 </methodology>
 
@@ -342,9 +342,9 @@ examples:
 
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST create the exploitation queue using the save-deliverable CLI tool:
-- **If vulnerabilities found:** Run save-deliverable CLI with `--type AUTHZ_QUEUE --content '{"vulnerabilities": [...]}'` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-- **If no vulnerabilities found:** Run save-deliverable CLI with `--type AUTHZ_QUEUE --content '{"vulnerabilities": []}'`.
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as structured output:
+- **If vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": [...]}` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
+- **If no vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": []}`.
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
 This file serves as the handoff mechanism and must always be created to signal completion.
 </exploitation_queue_requirements>
@@ -360,7 +360,7 @@ This file serves as the handoff mechanism and must always be created to signal c
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type AUTHZ_ANALYSIS --file-path "deliverables/authz_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: Run save-deliverable CLI with `--type AUTHZ_QUEUE --content '{"vulnerabilities": [...]}'`
+   - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**AUTHORIZATION ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-injection.txt
+++ b/apps/worker/prompts/vuln-injection.txt
@@ -43,7 +43,7 @@ Success criterion: Complete source-to-sink traces detailing path, sanitizers, si
 **Phase Sequence:** RECON (Complete) → **INJECTION ANALYSIS (You)** → EXPLOITATION (next phase)
 
 **Your Input:** `deliverables/recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/injection_exploitation_queue.json` (actionable vulnerabilities for exploitation)
+**Your Output:** `deliverables/injection_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, attack surfaces, endpoints, input vectors
@@ -297,7 +297,7 @@ Your report MUST use the following structure precisely:
 ## 1. Executive Summary
 
 - **Analysis Status:** Complete  
-- **Key Outcome:** Several high-confidence SQL injection injection vulnerabilities (both SQLi and Command Injection) were identified. All findings have been passed to the exploitation phase via the machine-readable queue at `deliverables/injection_exploitation_queue.json`.  
+- **Key Outcome:** Several high-confidence SQL injection injection vulnerabilities (both SQLi and Command Injection) were identified. All findings have been passed to the exploitation phase.  
 - **Purpose of this Document:** This report provides the strategic context, dominant patterns, and environmental intelligence necessary to effectively exploit the vulnerabilities listed in the queue. It is intended to be read alongside the JSON deliverable.  
 
 
@@ -345,29 +345,20 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 
 </deliverable_instructions>
 
-<exploitation_queue_requirements>
-**Exploitation Queue (MANDATORY)**
-
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
-
-- **If vulnerabilities found:** Your final response will be automatically captured as the exploitation queue JSON — include each exploitable injection vulnerability (verdict: "vulnerable") following the exploitation_queue_format
-- **If no vulnerabilities found:** Your final response must be `{"vulnerabilities": []}`
-
-This file serves as the handoff mechanism to the Exploitation phase and must always be created to signal completion of your analysis.
-</exploitation_queue_requirements>
 
 <conclusion_trigger>
 **COMPLETION REQUIREMENTS (ALL must be satisfied):**
 
 1. **Todo Completion:** ALL tasks in your TodoWrite list must be marked as "completed"
-2. **Deliverable Generation:** Both required deliverables must be successfully saved using the save-deliverable CLI tool:
+2. **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
    - **CHUNKED WRITING (MANDATORY):**
      1. Use the **Write** tool to create `deliverables/injection_analysis_deliverable.md` with the title and first major section
      2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type INJECTION_ANALYSIS --file-path "deliverables/injection_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+
+**Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**INJECTION ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-injection.txt
+++ b/apps/worker/prompts/vuln-injection.txt
@@ -93,7 +93,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 <data_format_specifications>
 
   <exploitation_queue_format>
-  **Purpose:** Defines the structure of the agent's final structured response — the exploitation queue JSON.
+  **Purpose:** Defines the format of the exploitation queue JSON.
 
   **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 		{
@@ -147,7 +147,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
     - Include a short rationale (e.g., "context mismatch: regex escape on ORDER BY keyword slot").
     - If concat occurred **after** sanitization, treat that sanitization as **non-effective** for this path.
   - **6) Append to findings list (consistent fields)**
-	  -  **If the verdict is `vulnerable`:** Include the finding in your final structured response's exploitation queue. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access. Ensure all fields in the `exploitation_queue_format`, including a minimal `witness_payload`, are populated.
+	  -  **If the verdict is `vulnerable`:** Include the finding in your exploitation queue. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access. Ensure all fields in the `exploitation_queue_format`, including a minimal `witness_payload`, are populated.
     - **If the verdict is `safe`:** DO NOT add the finding to the exploitation queue. These secure vectors must be documented later in the "Vectors Analyzed and Confirmed Secure" section of your final Markdown report (`deliverables/injection_analysis_deliverable.md`).
     - **If a single source is found to be vulnerable via multiple, distinct paths to different sinks, you must create a separate vulnerability entry in the exploitation queue for each unique vulnerable path.**
     - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
@@ -348,7 +348,7 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
 
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as your final structured response:
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
 
 - **If vulnerabilities found:** Your final response will be automatically captured as the exploitation queue JSON — include each exploitable injection vulnerability (verdict: "vulnerable") following the exploitation_queue_format
 - **If no vulnerabilities found:** Your final response must be `{"vulnerabilities": []}`

--- a/apps/worker/prompts/vuln-injection.txt
+++ b/apps/worker/prompts/vuln-injection.txt
@@ -367,7 +367,7 @@ This file serves as the handoff mechanism to the Exploitation phase and must alw
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type INJECTION_ANALYSIS --file-path "deliverables/injection_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+   - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**INJECTION ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-injection.txt
+++ b/apps/worker/prompts/vuln-injection.txt
@@ -81,10 +81,10 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 **Available Tools:**
 - **Task Agent (Code Analysis):** Your primary tool. Use it to ask targeted questions about the source code, map query/command construction paths, and verify sanitization coverage. MANDATORY for all source code analysis.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Browser Automation (playwright-cli skill):** For browser interactions with the live web application (multi-step flows like password reset or registration), invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each injection source that needs analysis. Mark items as "in_progress" when working on them and "completed" when done.

--- a/apps/worker/prompts/vuln-injection.txt
+++ b/apps/worker/prompts/vuln-injection.txt
@@ -93,7 +93,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 <data_format_specifications>
 
   <exploitation_queue_format>
-  **Purpose:** Defines the structure for a "exploitation queue" saved via the save-deliverable CLI with --type INJECTION_QUEUE.
+  **Purpose:** Defines the structure of the agent's final structured response — the exploitation queue JSON.
 
   **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 		{
@@ -147,7 +147,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
     - Include a short rationale (e.g., "context mismatch: regex escape on ORDER BY keyword slot").
     - If concat occurred **after** sanitization, treat that sanitization as **non-effective** for this path.
   - **6) Append to findings list (consistent fields)**
-	  -  **If the verdict is `vulnerable`:** Use the Write tool to log the finding in `deliverables/injection_exploitation_queue.json`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access. Ensure all fields in the `exploitation_queue_format`, including a minimal `witness_payload`, are populated.
+	  -  **If the verdict is `vulnerable`:** Include the finding in your final structured response's exploitation queue. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access. Ensure all fields in the `exploitation_queue_format`, including a minimal `witness_payload`, are populated.
     - **If the verdict is `safe`:** DO NOT add the finding to the exploitation queue. These secure vectors must be documented later in the "Vectors Analyzed and Confirmed Secure" section of your final Markdown report (`deliverables/injection_analysis_deliverable.md`).
     - **If a single source is found to be vulnerable via multiple, distinct paths to different sinks, you must create a separate vulnerability entry in the exploitation queue for each unique vulnerable path.**
     - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
@@ -348,10 +348,10 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
 
-Regardless of whether vulnerabilities are found, you MUST create the exploitation queue using the save-deliverable CLI tool:
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as your final structured response:
 
-- **If vulnerabilities found:** Run save-deliverable CLI with `--type INJECTION_QUEUE --content '{"vulnerabilities": [...]}'` with each exploitable injection vulnerability (verdict: "vulnerable") following the exploitation_queue_format
-- **If no vulnerabilities found:** Run save-deliverable CLI with `--type INJECTION_QUEUE --content '{"vulnerabilities": []}'`
+- **If vulnerabilities found:** Your final response will be automatically captured as the exploitation queue JSON — include each exploitable injection vulnerability (verdict: "vulnerable") following the exploitation_queue_format
+- **If no vulnerabilities found:** Your final response must be `{"vulnerabilities": []}`
 
 This file serves as the handoff mechanism to the Exploitation phase and must always be created to signal completion of your analysis.
 </exploitation_queue_requirements>
@@ -367,7 +367,7 @@ This file serves as the handoff mechanism to the Exploitation phase and must alw
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type INJECTION_ANALYSIS --file-path "deliverables/injection_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: Run save-deliverable CLI with `--type INJECTION_QUEUE --content '{"vulnerabilities": [...]}'`
+   - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both todo completion AND successful deliverable generation, announce "**INJECTION ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-ssrf.txt
+++ b/apps/worker/prompts/vuln-ssrf.txt
@@ -89,7 +89,7 @@ An **exploitable vulnerability** is a data flow where user-controlled input infl
 <data_format_specifications>
 
 <exploitation_queue_format>
-**Purpose:** Defines the structure of the agent's final structured response.
+**Purpose:** Defines the format of the exploitation queue JSON.
 **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability json (SSRF-VULN-XX)",
@@ -228,7 +228,7 @@ Rule: when uncertain, round down (favor Medium/Low) to minimize false positives.
 # Documenting Findings (MANDATORY)
 For each check you perform from the list above, you must make a final **verdict**.
 
-- If the verdict is **`vulnerable`**, you must include the finding in your final structured response's exploitation queue.
+- If the verdict is **`vulnerable`**, you must include the finding in your exploitation queue.
 - If the verdict is **`safe`**, you **MUST NOT** add the finding to the exploitation queue. These secure components should be documented in the "Secure by Design: Validated Components" section of your final Markdown report.
 </methodology>
 
@@ -286,7 +286,7 @@ These components were analyzed and found to have robust defenses. They are low-p
 
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as structured output:
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
 - **If vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": [...]}` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
 - **If no vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": []}`.
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.

--- a/apps/worker/prompts/vuln-ssrf.txt
+++ b/apps/worker/prompts/vuln-ssrf.txt
@@ -89,7 +89,7 @@ An **exploitable vulnerability** is a data flow where user-controlled input infl
 <data_format_specifications>
 
 <exploitation_queue_format>
-**Purpose:** Defines the structure for a "exploitation queue" saved via the save-deliverable CLI with --type SSRF_QUEUE.
+**Purpose:** Defines the structure of the agent's final structured response.
 **Structure:** The `vulnerability` JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability json (SSRF-VULN-XX)",
@@ -228,7 +228,7 @@ Rule: when uncertain, round down (favor Medium/Low) to minimize false positives.
 # Documenting Findings (MANDATORY)
 For each check you perform from the list above, you must make a final **verdict**.
 
-- If the verdict is **`vulnerable`**, you must document the finding using the save-deliverable CLI to update the exploitation queue.
+- If the verdict is **`vulnerable`**, you must include the finding in your final structured response's exploitation queue.
 - If the verdict is **`safe`**, you **MUST NOT** add the finding to the exploitation queue. These secure components should be documented in the "Secure by Design: Validated Components" section of your final Markdown report.
 </methodology>
 
@@ -286,9 +286,9 @@ These components were analyzed and found to have robust defenses. They are low-p
 
 <exploitation_queue_requirements>
 **Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST create the exploitation queue using the save-deliverable CLI tool:
-- **If vulnerabilities found:** Run save-deliverable CLI with `--type SSRF_QUEUE --content '{"vulnerabilities": [...]}'` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-- **If no vulnerabilities found:** Run save-deliverable CLI with `--type SSRF_QUEUE --content '{"vulnerabilities": []}'`.
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue as structured output:
+- **If vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": [...]}` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
+- **If no vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": []}`.
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
 This file serves as the handoff mechanism and must always be created to signal completion.
 </exploitation_queue_requirements>
@@ -304,7 +304,7 @@ This file serves as the handoff mechanism and must always be created to signal c
       3. Repeat step 2 for all remaining sections
       4. Run `save-deliverable` with `--type SSRF_ANALYSIS --file-path "deliverables/ssrf_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-    - Exploitation queue: Run save-deliverable CLI with `--type SSRF_QUEUE --content '{"vulnerabilities": [...]}'`
+    - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**SSRF ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-ssrf.txt
+++ b/apps/worker/prompts/vuln-ssrf.txt
@@ -77,10 +77,10 @@ An **exploitable vulnerability** is a data flow where user-controlled input infl
 **Available Tools:**
 - **Task Agent (Code Analysis):** Your primary tool. Use it to ask targeted questions about the source code, trace data flows, and understand HTTP client usage. MANDATORY for all source code analysis.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 - **Browser Automation (playwright-cli skill):** For browser interactions with the live web application (multi-step flows involving URL redirection or proxy functionality), invoke the `playwright-cli` skill to learn available commands. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each SSRF sink that needs analysis. Mark items as "in_progress" when working on them and "completed" when done.

--- a/apps/worker/prompts/vuln-ssrf.txt
+++ b/apps/worker/prompts/vuln-ssrf.txt
@@ -304,7 +304,7 @@ This file serves as the handoff mechanism and must always be created to signal c
       3. Repeat step 2 for all remaining sections
       4. Run `save-deliverable` with `--type SSRF_ANALYSIS --file-path "deliverables/ssrf_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-    - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+    - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**SSRF ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-ssrf.txt
+++ b/apps/worker/prompts/vuln-ssrf.txt
@@ -41,7 +41,7 @@ Success criterion: A complete source-to-sink trace for every identified SSRF vul
 **Phase Sequence:** RECON (Complete) → **SSRF ANALYSIS (You)** → EXPLOITATION (next phase)
 
 **Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/ssrf_exploitation_queue.json` (actionable vulnerabilities for exploitation)
+**Your Output:** `deliverables/ssrf_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, endpoints, and data flows
@@ -284,27 +284,20 @@ These components were analyzed and found to have robust defenses. They are low-p
 
 </deliverable_instructions>
 
-<exploitation_queue_requirements>
-**Exploitation Queue (MANDATORY)**
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
-- **If vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": [...]}` with each confirmed hypothesis following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-- **If no vulnerabilities found:** Your final response must be the exploitation queue JSON `{"vulnerabilities": []}`.
-- **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
-This file serves as the handoff mechanism and must always be created to signal completion.
-</exploitation_queue_requirements>
 
 <conclusion_trigger>
 **COMPLETION REQUIREMENTS (ALL must be satisfied):**
 
 1.  **Systematic Analysis:** ALL relevant API endpoints and request-making features identified in the reconnaissance deliverable must be analyzed for SSRF vulnerabilities.
-2.  **Deliverable Generation:** Both required deliverables must be successfully saved using the save-deliverable CLI tool:
+2.  **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
     - **CHUNKED WRITING (MANDATORY):**
       1. Use the **Write** tool to create `deliverables/ssrf_analysis_deliverable.md` with the title and first major section
       2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
       3. Repeat step 2 for all remaining sections
       4. Run `save-deliverable` with `--type SSRF_ANALYSIS --file-path "deliverables/ssrf_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-    - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+
+**Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.
 
 **ONLY AFTER** both systematic analysis AND successful deliverable generation, announce "**SSRF ANALYSIS COMPLETE**" and stop.
 

--- a/apps/worker/prompts/vuln-xss.txt
+++ b/apps/worker/prompts/vuln-xss.txt
@@ -82,10 +82,10 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 - **Browser Automation (playwright-cli skill):** MANDATORY for testing DOM-based XSS and form submission vectors. Invoke the `playwright-cli` skill to learn available commands. Use for stored XSS testing and client-side payload execution verification. Always pass `-s={{PLAYWRIGHT_SESSION}}` to every command for session isolation.
 - **TodoWrite Tool:** Use this to create and manage your analysis task list. Create a todo item for each sink you need to analyze.
 - **save-deliverable (CLI Tool):** Saves your deliverable files with automatic validation.
-  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<json>'`
-  - **Returns:** JSON to stdout: `{"status":"success","filepath":"...","validated":true}` or `{"status":"error","message":"...","retryable":true}`
+  - **Usage:** `save-deliverable --type <TYPE> --file-path <path>` or `--content '<text>'`
+  - **Returns:** JSON to stdout: `{"status":"success","filepath":"..."}` or `{"status":"error","message":"...","retryable":true}`
   - **For large reports:** Write to disk first, then use `--file-path`. Do NOT pass large reports via `--content`.
-  - **For JSON queues:** You may use `--content '{"vulnerabilities": [...]}'`. Queue files are validated automatically.
+
 - **Bash tool:** Use for creating directories, copying files, and other shell commands as needed.
 </cli_tools>
 

--- a/apps/worker/prompts/vuln-xss.txt
+++ b/apps/worker/prompts/vuln-xss.txt
@@ -293,7 +293,7 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type XSS_ANALYSIS --file-path "deliverables/xss_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+   - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 ONLY AFTER both systematic analysis AND successful deliverable generation, announce "XSS ANALYSIS COMPLETE" and stop.
 

--- a/apps/worker/prompts/vuln-xss.txt
+++ b/apps/worker/prompts/vuln-xss.txt
@@ -92,7 +92,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 <data_format_specifications>
 
 <exploitation_queue_format>
-Purpose: Defines the structure for a "exploitation queue" saved via the save-deliverable CLI with --type XSS_QUEUE.
+Purpose: Defines the structure of the agent's final structured response.
 Structure: The vulnerability JSON object MUST follow this exact format:
 	{
 		"ID": "unique ID for each vulnerability json (XSS-VULN-XX)",
@@ -177,7 +177,7 @@ This rulebook is used for the **Early Termination** check in Step 2.
 - Include both safe and vulnerable paths to demonstrate **full coverage**.  
 - Craft a minimal `witness_payload` that proves control over the render context.  
 - For every path analyzed, you must document the outcome. The location of the documentation depends on the verdict:
-		- If the verdict is 'vulnerable', you MUST use the save-deliverable CLI to save the finding to the exploitation queue, including complete source-to-sink information.
+		- If the verdict is 'vulnerable', you MUST include the finding in your final structured response's exploitation queue, including complete source-to-sink information.
 		- If the verdict is 'safe', you MUST NOT add it to the exploitation queue. Instead, you will document these secure paths in the "Vectors Analyzed and Confirmed Secure" table of your final analysis report.
 - For vulnerable findings, craft a minimal witness_payload that proves control over the render context.
 
@@ -272,10 +272,10 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 Regardless of whether vulnerabilities are found, you MUST create the exploitation queue using the save-deliverable CLI tool.
 
 - **If exploitable vulnerabilities found:**
-  Run save-deliverable CLI with `--type XSS_QUEUE --content '{"vulnerabilities": [...]}'` with each exploitable XSS vulnerability (verdict: "vulnerable") following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
+  Your final response must be `{"vulnerabilities": [...]}` with each exploitable XSS vulnerability (verdict: "vulnerable") following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
 
 - **If no exploitable vulnerabilities found:**
-  Run save-deliverable CLI with `--type XSS_QUEUE --content '{"vulnerabilities": []}'`
+  Your final response must be `{"vulnerabilities": []}`
 
 - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
 
@@ -293,7 +293,7 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type XSS_ANALYSIS --file-path "deliverables/xss_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: Run save-deliverable CLI with `--type XSS_QUEUE --content '{"vulnerabilities": [...]}'`
+   - Exploitation queue: Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
 
 ONLY AFTER both systematic analysis AND successful deliverable generation, announce "XSS ANALYSIS COMPLETE" and stop.
 

--- a/apps/worker/prompts/vuln-xss.txt
+++ b/apps/worker/prompts/vuln-xss.txt
@@ -41,7 +41,7 @@ Success criterion: Live confirmation of XSS execution for every vulnerability th
 **Phase Sequence:** RECON (Complete) → **XSS ANALYSIS (You)** → EXPLOITATION (next phase)
 
 **Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/xss_exploitation_queue.json` (actionable vulnerabilities for exploitation)
+**Your Output:** `deliverables/xss_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture
@@ -220,7 +220,7 @@ When you have systematically analyzed all input vectors, you MUST generate two f
 
 ## 1. Executive Summary
 - **Analysis Status:** Complete  
-- **Key Outcome:** Several high-confidence XSS vulnerabilities were identified. All findings have been passed to the exploitation phase via `deliverables/xss_exploitation_queue.json`.  
+- **Key Outcome:** Several high-confidence XSS vulnerabilities were identified. All findings have been passed to the exploitation phase.  
 - **Purpose of this Document:** This report provides the strategic context, dominant patterns, and environmental intelligence necessary to effectively exploit the vulnerabilities.  
 
 ## 2. Dominant Vulnerability Patterns
@@ -265,35 +265,20 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 
 </deliverable_instructions>
 
-<exploitation_queue_requirements>
-
-## Exploitation Queue (MANDATORY)
-
-Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
-
-- **If exploitable vulnerabilities found:**
-  Your final response must be `{"vulnerabilities": [...]}` with each exploitable XSS vulnerability (verdict: "vulnerable") following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.
-
-- **If no exploitable vulnerabilities found:**
-  Your final response must be `{"vulnerabilities": []}`
-
-- **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
-
-This file is the mandatory handoff to the Exploitation phase.
-</exploitation_queue_requirements>
 
 <conclusion_trigger>
 COMPLETION REQUIREMENTS (ALL must be satisfied):
 
 1. Systematic Analysis: ALL input vectors identified from the reconnaissance deliverable must be analyzed.
-2. Deliverable Generation: Both required deliverables must be successfully saved using the save-deliverable CLI tool:
+2. Deliverable Generation: Your deliverable must be successfully saved using the save-deliverable CLI tool:
    - **CHUNKED WRITING (MANDATORY):**
      1. Use the **Write** tool to create `deliverables/xss_analysis_deliverable.md` with the title and first major section
      2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
      3. Repeat step 2 for all remaining sections
      4. Run `save-deliverable` with `--type XSS_ANALYSIS --file-path "deliverables/xss_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
-   - Exploitation queue: You MUST save your deliverable markdown BEFORE this step. Your final response must be the exploitation queue JSON matching the `exploitation_queue_format` schema
+
+**Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.
 
 ONLY AFTER both systematic analysis AND successful deliverable generation, announce "XSS ANALYSIS COMPLETE" and stop.
 

--- a/apps/worker/prompts/vuln-xss.txt
+++ b/apps/worker/prompts/vuln-xss.txt
@@ -269,7 +269,7 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 
 ## Exploitation Queue (MANDATORY)
 
-Regardless of whether vulnerabilities are found, you MUST create the exploitation queue using the save-deliverable CLI tool.
+Regardless of whether vulnerabilities are found, you MUST produce the exploitation queue:
 
 - **If exploitable vulnerabilities found:**
   Your final response must be `{"vulnerabilities": [...]}` with each exploitable XSS vulnerability (verdict: "vulnerable") following the `exploitation_queue_format`. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access.

--- a/apps/worker/src/ai/claude-executor.ts
+++ b/apps/worker/src/ai/claude-executor.ts
@@ -6,7 +6,7 @@
 
 // Production Claude agent execution with retry, git checkpoints, and audit logging
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
+import { type JsonSchemaOutputFormat, query } from '@anthropic-ai/claude-agent-sdk';
 import { fs, path } from 'zx';
 import type { AuditSession } from '../audit/index.js';
 import { isRetryableError, PentestError } from '../services/error-handling.js';
@@ -39,6 +39,7 @@ export interface ClaudePromptResult {
   errorType?: string | undefined;
   prompt?: string | undefined;
   retryable?: boolean | undefined;
+  structuredOutput?: unknown;
 }
 
 function outputLines(lines: string[]): void {
@@ -132,6 +133,7 @@ export async function runClaudePrompt(
   auditSession: AuditSession | null = null,
   logger: ActivityLogger,
   modelTier: ModelTier = 'medium',
+  outputFormat?: JsonSchemaOutputFormat,
 ): Promise<ClaudePromptResult> {
   // 1. Initialize timing and prompt
   const timer = new Timer(`agent-${description.toLowerCase().replace(/\s+/g, '-')}`);
@@ -186,6 +188,7 @@ export async function runClaudePrompt(
     allowDangerouslySkipPermissions: true,
     settingSources: ['user'] as ('user' | 'project' | 'local')[],
     env: sdkEnv,
+    ...(outputFormat && { outputFormat }),
   };
 
   if (!execContext.useCleanOutput) {
@@ -243,6 +246,9 @@ export async function runClaudePrompt(
       model,
       partialCost: totalCost,
       apiErrorDetected,
+      ...(messageLoopResult.structuredOutput !== undefined && {
+        structuredOutput: messageLoopResult.structuredOutput,
+      }),
     };
   } catch (error) {
     // 9. Handle errors — log, write error file, return failure
@@ -273,6 +279,7 @@ interface MessageLoopResult {
   apiErrorDetected: boolean;
   cost: number;
   model?: string | undefined;
+  structuredOutput?: unknown;
 }
 
 interface MessageLoopDeps {
@@ -297,6 +304,7 @@ async function processMessageStream(
   let apiErrorDetected = false;
   let cost = 0;
   let model: string | undefined;
+  let structuredOutput: unknown | undefined;
   let lastHeartbeat = Date.now();
 
   for await (const message of query({ prompt: fullPrompt, options })) {
@@ -327,6 +335,9 @@ async function processMessageStream(
     if (dispatchResult.type === 'complete') {
       result = dispatchResult.result;
       cost = dispatchResult.cost;
+      if (dispatchResult.structuredOutput !== undefined) {
+        structuredOutput = dispatchResult.structuredOutput;
+      }
       break;
     }
 
@@ -341,5 +352,12 @@ async function processMessageStream(
     }
   }
 
-  return { turnCount, result, apiErrorDetected, cost, model };
+  return {
+    turnCount,
+    result,
+    apiErrorDetected,
+    cost,
+    model,
+    ...(structuredOutput !== undefined && { structuredOutput }),
+  };
 }

--- a/apps/worker/src/ai/message-handlers.ts
+++ b/apps/worker/src/ai/message-handlers.ts
@@ -223,6 +223,10 @@ function handleResultMessage(message: ResultMessage): ResultData {
     }
   }
 
+  if (message.structured_output !== undefined) {
+    result.structuredOutput = message.structured_output;
+  }
+
   return result;
 }
 
@@ -259,7 +263,7 @@ function outputLines(lines: string[]): void {
 
 export type MessageDispatchAction =
   | { type: 'continue'; apiErrorDetected?: boolean | undefined; model?: string | undefined }
-  | { type: 'complete'; result: string | null; cost: number }
+  | { type: 'complete'; result: string | null; cost: number; structuredOutput?: unknown }
   | { type: 'throw'; error: Error };
 
 export interface MessageDispatchDeps {
@@ -338,7 +342,26 @@ export async function dispatchMessage(
     case 'result': {
       const resultData = handleResultMessage(message as ResultMessage);
       outputLines(formatResultOutput(resultData, !execContext.useCleanOutput));
-      return { type: 'complete', result: resultData.result, cost: resultData.cost };
+
+      if (resultData.subtype === 'error_max_structured_output_retries') {
+        return {
+          type: 'throw',
+          error: new PentestError(
+            'Structured output validation failed after max retries',
+            'validation',
+            true,
+            {},
+            ErrorCode.OUTPUT_VALIDATION_FAILED,
+          ),
+        };
+      }
+
+      return {
+        type: 'complete' as const,
+        result: resultData.result,
+        cost: resultData.cost,
+        ...(resultData.structuredOutput !== undefined && { structuredOutput: resultData.structuredOutput }),
+      };
     }
 
     default:

--- a/apps/worker/src/ai/queue-schemas.ts
+++ b/apps/worker/src/ai/queue-schemas.ts
@@ -90,8 +90,10 @@ const AuthzQueueSchema = z.object({ vulnerabilities: z.array(AuthzVulnerability)
 
 // === Convert to JSON Schema for SDK ===
 
-function toOutputFormat(schema: z.ZodType): JsonSchemaOutputFormat {
-  return { type: 'json_schema', schema: z.toJSONSchema(schema) as Record<string, unknown> };
+// NOTE: The SDK's AJV validator expects draft-07. Zod defaults to draft-2020-12 which
+// causes the SDK to silently skip structured output.
+function toOutputFormat(zodSchema: z.ZodType): JsonSchemaOutputFormat {
+  return { type: 'json_schema', schema: z.toJSONSchema(zodSchema, { target: 'draft-07' }) as Record<string, unknown> };
 }
 
 // === Lookup Maps ===

--- a/apps/worker/src/ai/queue-schemas.ts
+++ b/apps/worker/src/ai/queue-schemas.ts
@@ -14,7 +14,6 @@
 import type { JsonSchemaOutputFormat } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 import type { AgentName } from '../types/agents.js';
-import { DELIVERABLE_FILENAMES, DeliverableType } from '../types/deliverables.js';
 
 // === Common Fields ===
 
@@ -107,11 +106,11 @@ const VULN_AGENT_OUTPUT_FORMAT: Partial<Record<AgentName, JsonSchemaOutputFormat
 };
 
 const VULN_AGENT_QUEUE_FILENAMES: Partial<Record<AgentName, string>> = {
-  'injection-vuln': DELIVERABLE_FILENAMES[DeliverableType.INJECTION_QUEUE],
-  'xss-vuln': DELIVERABLE_FILENAMES[DeliverableType.XSS_QUEUE],
-  'auth-vuln': DELIVERABLE_FILENAMES[DeliverableType.AUTH_QUEUE],
-  'ssrf-vuln': DELIVERABLE_FILENAMES[DeliverableType.SSRF_QUEUE],
-  'authz-vuln': DELIVERABLE_FILENAMES[DeliverableType.AUTHZ_QUEUE],
+  'injection-vuln': 'injection_exploitation_queue.json',
+  'xss-vuln': 'xss_exploitation_queue.json',
+  'auth-vuln': 'auth_exploitation_queue.json',
+  'ssrf-vuln': 'ssrf_exploitation_queue.json',
+  'authz-vuln': 'authz_exploitation_queue.json',
 };
 
 /** Returns the structured output format for a vuln agent, or undefined for non-vuln agents. */

--- a/apps/worker/src/ai/queue-schemas.ts
+++ b/apps/worker/src/ai/queue-schemas.ts
@@ -1,0 +1,123 @@
+// Copyright (C) 2025 Keygraph, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation.
+
+/**
+ * Zod schema definitions for vulnerability exploitation queue structured outputs.
+ *
+ * Each vuln agent returns a structured JSON response matching its schema.
+ * The SDK validates the output against the JSON Schema generated from these Zod definitions.
+ */
+
+import type { JsonSchemaOutputFormat } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import type { AgentName } from '../types/agents.js';
+import { DELIVERABLE_FILENAMES, DeliverableType } from '../types/deliverables.js';
+
+// === Common Fields ===
+
+const baseVulnerability = z.object({
+  ID: z.string(),
+  vulnerability_type: z.string(),
+  externally_exploitable: z.boolean(),
+  confidence: z.string(),
+  notes: z.string().optional(),
+});
+
+// === Per-Vuln-Type Schemas ===
+
+const InjectionVulnerability = baseVulnerability.extend({
+  source: z.string().optional(),
+  combined_sources: z.string().optional(),
+  path: z.string().optional(),
+  sink_call: z.string().optional(),
+  slot_type: z.string().optional(),
+  sanitization_observed: z.string().optional(),
+  concat_occurrences: z.string().optional(),
+  verdict: z.string().optional(),
+  mismatch_reason: z.string().optional(),
+  witness_payload: z.string().optional(),
+});
+
+const XssVulnerability = baseVulnerability.extend({
+  source: z.string().optional(),
+  source_detail: z.string().optional(),
+  path: z.string().optional(),
+  sink_function: z.string().optional(),
+  render_context: z.string().optional(),
+  encoding_observed: z.string().optional(),
+  verdict: z.string().optional(),
+  mismatch_reason: z.string().optional(),
+  witness_payload: z.string().optional(),
+});
+
+const AuthVulnerability = baseVulnerability.extend({
+  source_endpoint: z.string().optional(),
+  vulnerable_code_location: z.string().optional(),
+  missing_defense: z.string().optional(),
+  exploitation_hypothesis: z.string().optional(),
+  suggested_exploit_technique: z.string().optional(),
+});
+
+const SsrfVulnerability = baseVulnerability.extend({
+  source_endpoint: z.string().optional(),
+  vulnerable_parameter: z.string().optional(),
+  vulnerable_code_location: z.string().optional(),
+  missing_defense: z.string().optional(),
+  exploitation_hypothesis: z.string().optional(),
+  suggested_exploit_technique: z.string().optional(),
+});
+
+const AuthzVulnerability = baseVulnerability.extend({
+  endpoint: z.string().optional(),
+  vulnerable_code_location: z.string().optional(),
+  role_context: z.string().optional(),
+  guard_evidence: z.string().optional(),
+  side_effect: z.string().optional(),
+  reason: z.string().optional(),
+  minimal_witness: z.string().optional(),
+});
+
+// === Queue Wrapper Schemas ===
+
+const InjectionQueueSchema = z.object({ vulnerabilities: z.array(InjectionVulnerability) });
+const XssQueueSchema = z.object({ vulnerabilities: z.array(XssVulnerability) });
+const AuthQueueSchema = z.object({ vulnerabilities: z.array(AuthVulnerability) });
+const SsrfQueueSchema = z.object({ vulnerabilities: z.array(SsrfVulnerability) });
+const AuthzQueueSchema = z.object({ vulnerabilities: z.array(AuthzVulnerability) });
+
+// === Convert to JSON Schema for SDK ===
+
+function toOutputFormat(schema: z.ZodType): JsonSchemaOutputFormat {
+  return { type: 'json_schema', schema: z.toJSONSchema(schema) as Record<string, unknown> };
+}
+
+// === Lookup Maps ===
+
+const VULN_AGENT_OUTPUT_FORMAT: Partial<Record<AgentName, JsonSchemaOutputFormat>> = {
+  'injection-vuln': toOutputFormat(InjectionQueueSchema),
+  'xss-vuln': toOutputFormat(XssQueueSchema),
+  'auth-vuln': toOutputFormat(AuthQueueSchema),
+  'ssrf-vuln': toOutputFormat(SsrfQueueSchema),
+  'authz-vuln': toOutputFormat(AuthzQueueSchema),
+};
+
+const VULN_AGENT_QUEUE_FILENAMES: Partial<Record<AgentName, string>> = {
+  'injection-vuln': DELIVERABLE_FILENAMES[DeliverableType.INJECTION_QUEUE],
+  'xss-vuln': DELIVERABLE_FILENAMES[DeliverableType.XSS_QUEUE],
+  'auth-vuln': DELIVERABLE_FILENAMES[DeliverableType.AUTH_QUEUE],
+  'ssrf-vuln': DELIVERABLE_FILENAMES[DeliverableType.SSRF_QUEUE],
+  'authz-vuln': DELIVERABLE_FILENAMES[DeliverableType.AUTHZ_QUEUE],
+};
+
+/** Returns the structured output format for a vuln agent, or undefined for non-vuln agents. */
+export function getOutputFormat(agentName: AgentName): JsonSchemaOutputFormat | undefined {
+  return VULN_AGENT_OUTPUT_FORMAT[agentName];
+}
+
+/** Returns the queue filename for a vuln agent, or undefined for non-vuln agents. */
+export function getQueueFilename(agentName: AgentName): string | undefined {
+  return VULN_AGENT_QUEUE_FILENAMES[agentName];
+}

--- a/apps/worker/src/ai/types.ts
+++ b/apps/worker/src/ai/types.ts
@@ -34,6 +34,7 @@ export interface ResultData {
   subtype?: string;
   stop_reason?: string | null;
   permissionDenials: number;
+  structuredOutput?: unknown;
 }
 
 export interface ToolUseData {
@@ -69,6 +70,7 @@ export interface ResultMessage {
   subtype?: string;
   stop_reason?: string | null;
   permission_denials?: unknown[];
+  structured_output?: unknown;
 }
 
 export interface ToolUseMessage {

--- a/apps/worker/src/scripts/save-deliverable.ts
+++ b/apps/worker/src/scripts/save-deliverable.ts
@@ -9,17 +9,15 @@
 /**
  * save-deliverable CLI
  *
- * Standalone script to save deliverable files with validation.
- * Replaces the MCP save_deliverable tool.
+ * Standalone script to save deliverable files.
  *
  * Usage:
- *   node save-deliverable.js --type INJECTION_QUEUE --content '{"vulnerabilities": [...]}'
  *   node save-deliverable.js --type INJECTION_ANALYSIS --file-path deliverables/injection_analysis_deliverable.md
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { DELIVERABLE_FILENAMES, type DeliverableType, isQueueType } from '../types/deliverables.js';
+import { DELIVERABLE_FILENAMES, type DeliverableType } from '../types/deliverables.js';
 
 // === Argument Parsing ===
 
@@ -49,49 +47,6 @@ function parseArgs(argv: string[]): ParsedArgs {
   }
 
   return args;
-}
-
-// === Queue Validation ===
-
-interface ValidationResult {
-  valid: boolean;
-  message?: string;
-}
-
-function validateQueueJson(content: string): ValidationResult {
-  try {
-    const parsed = JSON.parse(content) as unknown;
-
-    if (typeof parsed !== 'object' || parsed === null) {
-      return {
-        valid: false,
-        message: `Invalid queue structure: Expected an object. Got: ${typeof parsed}`,
-      };
-    }
-
-    const obj = parsed as Record<string, unknown>;
-
-    if (!('vulnerabilities' in obj)) {
-      return {
-        valid: false,
-        message: `Invalid queue structure: Missing 'vulnerabilities' property. Expected: {"vulnerabilities": [...]}`,
-      };
-    }
-
-    if (!Array.isArray(obj.vulnerabilities)) {
-      return {
-        valid: false,
-        message: `Invalid queue structure: 'vulnerabilities' must be an array. Expected: {"vulnerabilities": [...]}`,
-      };
-    }
-
-    return { valid: true };
-  } catch (error) {
-    return {
-      valid: false,
-      message: `Invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
 }
 
 // === File Operations ===
@@ -165,22 +120,11 @@ function main(): void {
     process.exit(1);
   }
 
-  // 3. Validate queue types
-  let validated = false;
-  if (isQueueType(args.type)) {
-    const validation = validateQueueJson(content);
-    if (!validation.valid) {
-      console.log(JSON.stringify({ status: 'error', message: validation.message, retryable: true }));
-      process.exit(1);
-    }
-    validated = true;
-  }
-
-  // 4. Save the file
+  // 3. Save the file
   try {
     const targetDir = process.cwd();
     const filepath = saveDeliverableFile(targetDir, filename, content);
-    console.log(JSON.stringify({ status: 'success', filepath, validated }));
+    console.log(JSON.stringify({ status: 'success', filepath }));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     console.log(JSON.stringify({ status: 'error', message: `Failed to save: ${msg}`, retryable: true }));

--- a/apps/worker/src/services/agent-execution.ts
+++ b/apps/worker/src/services/agent-execution.ts
@@ -21,7 +21,9 @@
  * No Temporal dependencies - pure domain logic.
  */
 
+import { fs, path } from 'zx';
 import { type ClaudePromptResult, runClaudePrompt, validateAgentOutput } from '../ai/claude-executor.js';
+import { getOutputFormat, getQueueFilename } from '../ai/queue-schemas.js';
 import type { AuditSession } from '../audit/index.js';
 import { AGENTS } from '../session-manager.js';
 import type { ActivityLogger } from '../types/activity-logger.js';
@@ -134,6 +136,7 @@ export class AgentExecutionService {
     await auditSession.startAgent(agentName, prompt, attemptNumber);
 
     // 5. Execute agent
+    const outputFormat = getOutputFormat(agentName);
     const result: ClaudePromptResult = await runClaudePrompt(
       prompt,
       repoPath,
@@ -143,6 +146,7 @@ export class AgentExecutionService {
       auditSession,
       logger,
       AGENTS[agentName].modelTier,
+      outputFormat,
     );
 
     // 6. Spending cap check - defense-in-depth
@@ -176,7 +180,17 @@ export class AgentExecutionService {
       });
     }
 
-    // 8. Validate output
+    // 8. Write structured output to disk (vuln agents only)
+    const queueFilename = getQueueFilename(agentName);
+    if (result.structuredOutput !== undefined && queueFilename) {
+      const deliverablesDir = path.join(repoPath, 'deliverables');
+      await fs.ensureDir(deliverablesDir);
+      const queuePath = path.join(deliverablesDir, queueFilename);
+      await fs.writeFile(queuePath, JSON.stringify(result.structuredOutput, null, 2), 'utf8');
+      logger.info(`Wrote structured output queue to ${queueFilename}`);
+    }
+
+    // 9. Validate output
     const validationPassed = await validateAgentOutput(result, agentName, repoPath, logger);
     if (!validationPassed) {
       return this.failAgent(agentName, repoPath, auditSession, logger, {
@@ -191,7 +205,7 @@ export class AgentExecutionService {
       });
     }
 
-    // 9. Success - commit deliverables, then capture checkpoint hash
+    // 10. Success - commit deliverables, then capture checkpoint hash
     await commitGitSuccess(repoPath, agentName, logger);
     const commitHash = await getGitCommitHash(repoPath);
 

--- a/apps/worker/src/services/queue-validation.ts
+++ b/apps/worker/src/services/queue-validation.ts
@@ -114,12 +114,12 @@ function getExistenceErrorMessage(existence: FileExistence): string {
   const { deliverableExists, queueExists } = existence;
 
   if (!deliverableExists && !queueExists) {
-    return 'Analysis failed: Neither deliverable nor queue file exists. Analysis agent must create both files.';
+    return 'Analysis failed: Neither deliverable nor queue file exists. Both are required.';
   }
   if (!queueExists) {
-    return 'Analysis incomplete: Deliverable exists but queue file missing. Analysis agent must create both files.';
+    return 'Analysis incomplete: Deliverable exists but queue file missing. Both are required.';
   }
-  return 'Analysis incomplete: Queue exists but deliverable file missing. Analysis agent must create both files.';
+  return 'Analysis incomplete: Queue exists but deliverable file missing. Both are required.';
 }
 
 // Pure function to create file paths

--- a/apps/worker/src/types/deliverables.ts
+++ b/apps/worker/src/types/deliverables.ts
@@ -7,7 +7,7 @@
 /**
  * Deliverable Type Definitions
  *
- * Maps deliverable types to their filenames and defines validation requirements.
+ * Maps deliverable types to their filenames for the save-deliverable CLI.
  */
 
 export enum DeliverableType {
@@ -19,19 +19,10 @@ export enum DeliverableType {
 
   // Vulnerability analysis agents
   INJECTION_ANALYSIS = 'INJECTION_ANALYSIS',
-  INJECTION_QUEUE = 'INJECTION_QUEUE',
-
   XSS_ANALYSIS = 'XSS_ANALYSIS',
-  XSS_QUEUE = 'XSS_QUEUE',
-
   AUTH_ANALYSIS = 'AUTH_ANALYSIS',
-  AUTH_QUEUE = 'AUTH_QUEUE',
-
   AUTHZ_ANALYSIS = 'AUTHZ_ANALYSIS',
-  AUTHZ_QUEUE = 'AUTHZ_QUEUE',
-
   SSRF_ANALYSIS = 'SSRF_ANALYSIS',
-  SSRF_QUEUE = 'SSRF_QUEUE',
 
   // Exploitation agents
   INJECTION_EVIDENCE = 'INJECTION_EVIDENCE',
@@ -48,47 +39,13 @@ export const DELIVERABLE_FILENAMES: Record<DeliverableType, string> = {
   [DeliverableType.CODE_ANALYSIS]: 'code_analysis_deliverable.md',
   [DeliverableType.RECON]: 'recon_deliverable.md',
   [DeliverableType.INJECTION_ANALYSIS]: 'injection_analysis_deliverable.md',
-  [DeliverableType.INJECTION_QUEUE]: 'injection_exploitation_queue.json',
   [DeliverableType.XSS_ANALYSIS]: 'xss_analysis_deliverable.md',
-  [DeliverableType.XSS_QUEUE]: 'xss_exploitation_queue.json',
   [DeliverableType.AUTH_ANALYSIS]: 'auth_analysis_deliverable.md',
-  [DeliverableType.AUTH_QUEUE]: 'auth_exploitation_queue.json',
   [DeliverableType.AUTHZ_ANALYSIS]: 'authz_analysis_deliverable.md',
-  [DeliverableType.AUTHZ_QUEUE]: 'authz_exploitation_queue.json',
   [DeliverableType.SSRF_ANALYSIS]: 'ssrf_analysis_deliverable.md',
-  [DeliverableType.SSRF_QUEUE]: 'ssrf_exploitation_queue.json',
   [DeliverableType.INJECTION_EVIDENCE]: 'injection_exploitation_evidence.md',
   [DeliverableType.XSS_EVIDENCE]: 'xss_exploitation_evidence.md',
   [DeliverableType.AUTH_EVIDENCE]: 'auth_exploitation_evidence.md',
   [DeliverableType.AUTHZ_EVIDENCE]: 'authz_exploitation_evidence.md',
   [DeliverableType.SSRF_EVIDENCE]: 'ssrf_exploitation_evidence.md',
 };
-
-/**
- * Queue types that require JSON validation
- */
-export const QUEUE_TYPES: DeliverableType[] = [
-  DeliverableType.INJECTION_QUEUE,
-  DeliverableType.XSS_QUEUE,
-  DeliverableType.AUTH_QUEUE,
-  DeliverableType.AUTHZ_QUEUE,
-  DeliverableType.SSRF_QUEUE,
-];
-
-/**
- * Type guard to check if a deliverable type is a queue
- */
-export function isQueueType(type: string): boolean {
-  return QUEUE_TYPES.includes(type as DeliverableType);
-}
-
-/**
- * Vulnerability queue structure
- */
-export interface VulnerabilityQueue {
-  vulnerabilities: VulnerabilityItem[];
-}
-
-export interface VulnerabilityItem {
-  [key: string]: unknown;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zx:
         specifier: ^8.0.0
         version: 8.8.5


### PR DESCRIPTION
## Summary

- Replace save-deliverable tool calls for exploitation queue JSON with Claude Agent SDK's native `outputFormat`, getting schema-validated structured data directly from vuln agents
- Add Zod schemas for all 5 vulnerability types (injection, xss, auth, ssrf, authz) with draft-07 JSON Schema conversion for SDK AJV compatibility
- Simplify save-deliverable by removing all queue-related code paths — it now only handles markdown deliverables
- Update all vuln and exploit prompts to reflect the new flow: agents save their markdown deliverable first, then the SDK automatically captures the exploitation queue as structured output on the last turn