### PR TITLE
feat: mount user repo as read-only with writable shannon overlay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Node.js
-node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -49,8 +49,7 @@ Thumbs.db
 # CLI package (runs on host, not in container)
 # Keep apps/cli/package.json so pnpm workspaces resolve
 apps/cli/src/
-apps/cli/dist/
-apps/worker/dist/
+**/dist/
 apps/cli/infra/
 apps/cli/tsconfig.json
 apps/cli/tsdown.config.ts

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,7 @@ RUN ln -s /app/apps/worker/dist/scripts/save-deliverable.js /usr/local/bin/save-
     chmod +x /app/apps/worker/dist/scripts/generate-totp.js
 
 # Create directories for session data and ensure proper permissions
-RUN mkdir -p /app/sessions /app/deliverables /app/repos /app/workspaces && \
+RUN mkdir -p /app/sessions /app/repos /app/workspaces && \
     mkdir -p /tmp/.cache /tmp/.config /tmp/.npm && \
     chmod 777 /app && \
     chmod 777 /tmp/.cache && \

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -12,7 +12,7 @@ import { ensureImage, ensureInfra, randomSuffix, spawnWorker } from '../docker.j
 import { buildEnvFlags, isRouterConfigured, loadEnv, validateCredentials } from '../env.js';
 import { getCredentialsPath, getWorkspacesDir, initHome } from '../home.js';
 import { isLocal } from '../mode.js';
-import { ensureDeliverables, resolveConfig, resolveRepo } from '../paths.js';
+import { resolveConfig, resolveRepo } from '../paths.js';
 import { displaySplash } from '../splash.js';
 
 export interface StartArgs {
@@ -42,7 +42,6 @@ export async function start(args: StartArgs): Promise<void> {
   // 3. Resolve paths
   const repo = resolveRepo(args.repo);
   const config = args.config ? resolveConfig(args.config) : undefined;
-  ensureDeliverables(repo.hostPath);
 
   // 4. Ensure workspaces dir is writable by container user (UID 1001)
   const workspacesDir = getWorkspacesDir();
@@ -68,7 +67,12 @@ export async function start(args: StartArgs): Promise<void> {
   const workspace =
     args.workspace ?? `${new URL(args.url).hostname.replace(/[^a-zA-Z0-9-]/g, '-')}_shannon-${Date.now()}`;
 
-  // 9. Resolve credentials — mount single file to fixed container path
+  // 9. Create workspace deliverables directory (mounted over repo/deliverables inside container)
+  const workspaceDeliverables = path.join(workspacesDir, workspace, 'deliverables');
+  fs.mkdirSync(workspaceDeliverables, { recursive: true });
+  fs.chmodSync(workspaceDeliverables, 0o777);
+
+  // 10. Resolve credentials — mount single file to fixed container path
   const credentialsPath = getCredentialsPath();
   const hasCredentials = fs.existsSync(credentialsPath);
 
@@ -101,7 +105,7 @@ export async function start(args: StartArgs): Promise<void> {
     ...(hasCredentials && { credentials: credentialsPath }),
     ...(promptsDir && { promptsDir }),
     ...(outputDir && { outputDir }),
-    ...(workspace && { workspace }),
+    workspace,
     ...(args.pipelineTesting && { pipelineTesting: true }),
   });
 

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -67,10 +67,13 @@ export async function start(args: StartArgs): Promise<void> {
   const workspace =
     args.workspace ?? `${new URL(args.url).hostname.replace(/[^a-zA-Z0-9-]/g, '-')}_shannon-${Date.now()}`;
 
-  // 9. Create workspace deliverables directory (mounted over repo/deliverables inside container)
-  const workspaceDeliverables = path.join(workspacesDir, workspace, 'deliverables');
-  fs.mkdirSync(workspaceDeliverables, { recursive: true });
-  fs.chmodSync(workspaceDeliverables, 0o777);
+  // 9. Create writable overlay directories (mounted over :ro repo paths inside container)
+  const workspacePath = path.join(workspacesDir, workspace);
+  for (const dir of ['deliverables', 'playground', '.playwright-cli']) {
+    const dirPath = path.join(workspacePath, dir);
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.chmodSync(dirPath, 0o777);
+  }
 
   // 10. Resolve credentials — mount single file to fixed container path
   const credentialsPath = getCredentialsPath();

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -69,7 +69,7 @@ export async function start(args: StartArgs): Promise<void> {
 
   // 9. Create writable overlay directories (mounted over :ro repo paths inside container)
   const workspacePath = path.join(workspacesDir, workspace);
-  for (const dir of ['deliverables', 'playground', '.playwright-cli']) {
+  for (const dir of ['deliverables', 'scratchpad', '.playwright-cli']) {
     const dirPath = path.join(workspacePath, dir);
     fs.mkdirSync(dirPath, { recursive: true });
     fs.chmodSync(dirPath, 0o777);

--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -75,7 +75,12 @@ export async function start(args: StartArgs): Promise<void> {
     fs.chmodSync(dirPath, 0o777);
   }
 
-  // 10. Resolve credentials — mount single file to fixed container path
+  // 10. Pre-create overlay mount points (Linux :ro mounts can't auto-create them)
+  const shannonDir = path.join(repo.hostPath, '.shannon');
+  for (const dir of ['deliverables', 'scratchpad', '.playwright-cli']) {
+    fs.mkdirSync(path.join(shannonDir, dir), { recursive: true });
+  }
+
   const credentialsPath = getCredentialsPath();
   const hasCredentials = fs.existsSync(credentialsPath);
 

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -216,9 +216,11 @@ export function spawnWorker(opts: WorkerOptions): ChildProcess {
   args.push('-v', `${opts.workspacesDir}:/app/workspaces`);
   args.push('-v', `${opts.repo.hostPath}:${opts.repo.containerPath}:ro`);
 
-  // Deliverables overlay: writable workspace dir shadows the :ro repo's deliverables/
-  const deliverablesMountSrc = path.join(opts.workspacesDir, opts.workspace, 'deliverables');
-  args.push('-v', `${deliverablesMountSrc}:${opts.repo.containerPath}/deliverables`);
+  // Writable overlays: shadow specific paths inside the :ro repo with workspace-backed dirs
+  const workspacePath = path.join(opts.workspacesDir, opts.workspace);
+  args.push('-v', `${path.join(workspacePath, 'deliverables')}:${opts.repo.containerPath}/deliverables`);
+  args.push('-v', `${path.join(workspacePath, 'playground')}:${opts.repo.containerPath}/playground`);
+  args.push('-v', `${path.join(workspacePath, '.playwright-cli')}:${opts.repo.containerPath}/.playwright-cli`);
 
   // Local mode: mount prompts for live editing
   if (opts.promptsDir) {

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -216,11 +216,11 @@ export function spawnWorker(opts: WorkerOptions): ChildProcess {
   args.push('-v', `${opts.workspacesDir}:/app/workspaces`);
   args.push('-v', `${opts.repo.hostPath}:${opts.repo.containerPath}:ro`);
 
-  // Writable overlays: shadow specific paths inside the :ro repo with workspace-backed dirs
+  // Writable overlays: shadow .shannon/ inside the :ro repo with workspace-backed dirs
   const workspacePath = path.join(opts.workspacesDir, opts.workspace);
-  args.push('-v', `${path.join(workspacePath, 'deliverables')}:${opts.repo.containerPath}/deliverables`);
-  args.push('-v', `${path.join(workspacePath, 'playground')}:${opts.repo.containerPath}/playground`);
-  args.push('-v', `${path.join(workspacePath, '.playwright-cli')}:${opts.repo.containerPath}/.playwright-cli`);
+  args.push('-v', `${path.join(workspacePath, 'deliverables')}:${opts.repo.containerPath}/.shannon/deliverables`);
+  args.push('-v', `${path.join(workspacePath, 'playground')}:${opts.repo.containerPath}/.shannon/playground`);
+  args.push('-v', `${path.join(workspacePath, '.playwright-cli')}:${opts.repo.containerPath}/.shannon/.playwright-cli`);
 
   // Local mode: mount prompts for live editing
   if (opts.promptsDir) {

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -219,7 +219,7 @@ export function spawnWorker(opts: WorkerOptions): ChildProcess {
   // Writable overlays: shadow .shannon/ inside the :ro repo with workspace-backed dirs
   const workspacePath = path.join(opts.workspacesDir, opts.workspace);
   args.push('-v', `${path.join(workspacePath, 'deliverables')}:${opts.repo.containerPath}/.shannon/deliverables`);
-  args.push('-v', `${path.join(workspacePath, 'playground')}:${opts.repo.containerPath}/.shannon/playground`);
+  args.push('-v', `${path.join(workspacePath, 'scratchpad')}:${opts.repo.containerPath}/.shannon/scratchpad`);
   args.push('-v', `${path.join(workspacePath, '.playwright-cli')}:${opts.repo.containerPath}/.shannon/.playwright-cli`);
 
   // Local mode: mount prompts for live editing

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -194,7 +194,7 @@ export interface WorkerOptions {
   credentials?: string;
   promptsDir?: string;
   outputDir?: string;
-  workspace?: string;
+  workspace: string;
   pipelineTesting?: boolean;
 }
 
@@ -214,7 +214,11 @@ export function spawnWorker(opts: WorkerOptions): ChildProcess {
 
   // Volume mounts
   args.push('-v', `${opts.workspacesDir}:/app/workspaces`);
-  args.push('-v', `${opts.repo.hostPath}:${opts.repo.containerPath}`);
+  args.push('-v', `${opts.repo.hostPath}:${opts.repo.containerPath}:ro`);
+
+  // Deliverables overlay: writable workspace dir shadows the :ro repo's deliverables/
+  const deliverablesMountSrc = path.join(opts.workspacesDir, opts.workspace, 'deliverables');
+  args.push('-v', `${deliverablesMountSrc}:${opts.repo.containerPath}/deliverables`);
 
   // Local mode: mount prompts for live editing
   if (opts.promptsDir) {
@@ -253,9 +257,7 @@ export function spawnWorker(opts: WorkerOptions): ChildProcess {
   if (opts.outputDir) {
     args.push('--output', '/app/output');
   }
-  if (opts.workspace) {
-    args.push('--workspace', opts.workspace);
-  }
+  args.push('--workspace', opts.workspace);
   if (opts.pipelineTesting) {
     args.push('--pipeline-testing');
   }

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -76,12 +76,3 @@ export function resolveConfig(configArg: string): MountPair {
     containerPath: `/app/configs/${basename}`,
   };
 }
-
-/**
- * Ensure the deliverables directory exists and is writable by the container user.
- */
-export function ensureDeliverables(repoHostPath: string): void {
-  const deliverables = path.join(repoHostPath, 'deliverables');
-  fs.mkdirSync(deliverables, { recursive: true });
-  fs.chmodSync(deliverables, 0o777);
-}

--- a/apps/worker/prompts/exploit-auth.txt
+++ b/apps/worker/prompts/exploit-auth.txt
@@ -106,13 +106,13 @@ If you only confirmed a vulnerability without attempting to weaponize it, you ha
 </login_instructions>
 
 <starting_context>
-- Your **actionable exploitation queue** is located at `deliverables/auth_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
+- Your **actionable exploitation queue** is located at `.shannon/deliverables/auth_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
 
 **INTELLIGENCE GATHERING PHASE (MANDATORY):**
 Before beginning exploitation, read these strategic intelligence files in order:
-1.  `deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and authentication code locations.
-2.  `deliverables/recon_deliverable.md` - Complete API inventory, user roles, and data flow maps.
-3.  `deliverables/auth_analysis_deliverable.md` - Strategic context from the Auth analysis specialist, including notes on session mechanisms, password policies, and flawed logic paths.
+1.  `.shannon/deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and authentication code locations.
+2.  `.shannon/deliverables/recon_deliverable.md` - Complete API inventory, user roles, and data flow maps.
+3.  `.shannon/deliverables/auth_analysis_deliverable.md` - Strategic context from the Auth analysis specialist, including notes on session mechanisms, password policies, and flawed logic paths.
 
 - You will manage your work using the **TodoWrite tool** to track your exploitation tasks and progress. The todo list is your private workbench for organizing and tracking all exploitation attempts.
 </starting_context>
@@ -122,13 +122,13 @@ Before beginning exploitation, read these strategic intelligence files in order:
 
 **Phase Sequence:** VULN ANALYSIS (Complete) → **AUTH EXPLOITATION (You)** → FINAL REPORT (next phase)
 
-**Your Input:** `deliverables/auth_exploitation_queue.json` (primary exploitation queue)
-**Your Output:** `deliverables/auth_exploitation_evidence.md` (exploitation evidence)
+**Your Input:** `.shannon/deliverables/auth_exploitation_queue.json` (primary exploitation queue)
+**Your Output:** `.shannon/deliverables/auth_exploitation_evidence.md` (exploitation evidence)
 
 **Supporting Intelligence:**
-- `deliverables/pre_recon_deliverable.md` (architecture & code context)
-- `deliverables/recon_deliverable.md` (API inventory & user roles)
-- `deliverables/auth_analysis_deliverable.md` (strategic intel)
+- `.shannon/deliverables/pre_recon_deliverable.md` (architecture & code context)
+- `.shannon/deliverables/recon_deliverable.md` (API inventory & user roles)
+- `.shannon/deliverables/auth_analysis_deliverable.md` (strategic intel)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture and attack surfaces
@@ -189,7 +189,7 @@ Your primary goal is to achieve a definitive, evidence-backed conclusion for **e
 Your entire exploitation process will be managed through the TodoWrite tool. You MUST adhere to this process.
 
 **1. Initialization:**
-- Read `deliverables/auth_exploitation_queue.json`.
+- Read `.shannon/deliverables/auth_exploitation_queue.json`.
 - Use the TodoWrite tool to create tasks for each vulnerability in the queue.
 - Each task should include the vulnerability ID and the hypothesis to test.
     Example tasks:
@@ -315,7 +315,7 @@ When your attack plan is fully explored (all checkboxes are marked `[x]`), your 
 First, synthesize all evidence into your specialist section and save it using the save-deliverable CLI with --type AUTH_EVIDENCE. This section will be combined with other specialist reports to form the complete security assessment.
 
 **Section Ordering & Format Requirements:**
-- Use the exact vulnerability IDs from `deliverables/auth_exploitation_queue.json`
+- Use the exact vulnerability IDs from `.shannon/deliverables/auth_exploitation_queue.json`
 - Within "Successfully Exploited" section: Order by severity of impact (most critical first)
 - Within "Confirmed Vulnerabilities (Attempted Exploitation)" section: Order by severity (most critical first)
 - Within "Potential" section: Order by confidence level (highest confidence first)
@@ -407,13 +407,13 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 	1. Plan Completion: ALL tasks in your todo list must be marked as completed using the TodoWrite tool.
 	2. Deliverable Generation: The required deliverable must be successfully saved using the save-deliverable CLI:
 	  - **CHUNKED WRITING (MANDATORY):**
-	    1. Use the **Write** tool to create `deliverables/auth_exploitation_evidence.md` with the title and first major section
+	    1. Use the **Write** tool to create `.shannon/deliverables/auth_exploitation_evidence.md` with the title and first major section
 	    2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
 	    3. Repeat step 2 for all remaining sections
-	    4. Run `save-deliverable` with `--type AUTH_EVIDENCE --file-path "deliverables/auth_exploitation_evidence.md"`
+	    4. Run `save-deliverable` with `--type AUTH_EVIDENCE --file-path ".shannon/deliverables/auth_exploitation_evidence.md"`
 	    **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
-CRITICAL WARNING: Announcing completion before every item in deliverables/auth_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
+CRITICAL WARNING: Announcing completion before every item in .shannon/deliverables/auth_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
 
 ONLY AFTER fulfilling these exhaustive requirements, announce "AUTH EXPLOITATION COMPLETE" and stop.
 

--- a/apps/worker/prompts/exploit-authz.txt
+++ b/apps/worker/prompts/exploit-authz.txt
@@ -93,13 +93,13 @@ After exhaustive bypass attempts, determine:
 </login_instructions>
 
 <starting_context>
-- Your **actionable exploitation queue** is located at `deliverables/authz_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
+- Your **actionable exploitation queue** is located at `.shannon/deliverables/authz_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
 
 **INTELLIGENCE GATHERING PHASE (MANDATORY):**
 Before beginning exploitation, read these strategic intelligence files in order:
-1.  `deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and authorization code locations.
-2.  `deliverables/recon_deliverable.md` - Complete API inventory, user roles, and permission models.
-3.  `deliverables/authz_analysis_deliverable.md` - Strategic context from the Authz analysis specialist, including notes on access control patterns, role hierarchies, and flawed logic paths.
+1.  `.shannon/deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and authorization code locations.
+2.  `.shannon/deliverables/recon_deliverable.md` - Complete API inventory, user roles, and permission models.
+3.  `.shannon/deliverables/authz_analysis_deliverable.md` - Strategic context from the Authz analysis specialist, including notes on access control patterns, role hierarchies, and flawed logic paths.
 
 - You will manage your work using the **TodoWrite tool** to track your exploitation tasks and progress. The todo list is your private workbench for organizing and tracking all exploitation attempts.
 </starting_context>
@@ -109,13 +109,13 @@ Before beginning exploitation, read these strategic intelligence files in order:
 
 **Phase Sequence:** VULN ANALYSIS (Complete) → **AUTHZ EXPLOITATION (You)** → FINAL REPORT (next phase)
 
-**Your Input:** `deliverables/authz_exploitation_queue.json` (primary exploitation queue)
-**Your Output:** `deliverables/authz_exploitation_evidence.md` (exploitation evidence)
+**Your Input:** `.shannon/deliverables/authz_exploitation_queue.json` (primary exploitation queue)
+**Your Output:** `.shannon/deliverables/authz_exploitation_evidence.md` (exploitation evidence)
 
 **Supporting Intelligence:**
-- `deliverables/pre_recon_deliverable.md` (architecture & code context)
-- `deliverables/recon_deliverable.md` (API inventory & user roles)
-- `deliverables/authz_analysis_deliverable.md` (strategic intel)
+- `.shannon/deliverables/pre_recon_deliverable.md` (architecture & code context)
+- `.shannon/deliverables/recon_deliverable.md` (API inventory & user roles)
+- `.shannon/deliverables/authz_analysis_deliverable.md` (strategic intel)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture and attack surfaces
@@ -176,7 +176,7 @@ Your primary goal is to achieve a definitive, evidence-backed conclusion for **e
 Your entire exploitation process will be managed through the TodoWrite tool. You MUST adhere to this process.
 
 **1. Initialization:**
-- Read `deliverables/authz_exploitation_queue.json`.
+- Read `.shannon/deliverables/authz_exploitation_queue.json`.
 - Use the TodoWrite tool to create tasks for each vulnerability in the queue.
 - Each task should include the vulnerability ID, type, and the hypothesis to test.
     Example tasks:
@@ -321,7 +321,7 @@ When your attack plan is fully explored (all checkboxes are marked `[x]`), your 
 First, synthesize all evidence into your specialist section and save it using the save-deliverable CLI with --type AUTHZ_EVIDENCE. This section will be combined with other specialist reports to form the complete security assessment and MUST use the following structure:
 
 **Section Ordering & Format Requirements:**
-- Use the exact vulnerability IDs from `deliverables/authz_exploitation_queue.json`
+- Use the exact vulnerability IDs from `.shannon/deliverables/authz_exploitation_queue.json`
 - Within "Successfully Exploited" section: Order by severity of impact (most critical first)
 - Within "Potential" section: Order by confidence level (highest confidence first)
 
@@ -409,13 +409,13 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 	1. Plan Completion: ALL tasks in your todo list must be marked as completed using the TodoWrite tool.
 	2. Deliverable Generation: The required deliverable must be successfully saved using the save-deliverable CLI:
 	  - **CHUNKED WRITING (MANDATORY):**
-	    1. Use the **Write** tool to create `deliverables/authz_exploitation_evidence.md` with the title and first major section
+	    1. Use the **Write** tool to create `.shannon/deliverables/authz_exploitation_evidence.md` with the title and first major section
 	    2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
 	    3. Repeat step 2 for all remaining sections
-	    4. Run `save-deliverable` with `--type AUTHZ_EVIDENCE --file-path "deliverables/authz_exploitation_evidence.md"`
+	    4. Run `save-deliverable` with `--type AUTHZ_EVIDENCE --file-path ".shannon/deliverables/authz_exploitation_evidence.md"`
 	    **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
-CRITICAL WARNING: Announcing completion before every item in deliverables/authz_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
+CRITICAL WARNING: Announcing completion before every item in .shannon/deliverables/authz_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
 
 ONLY AFTER fulfilling these exhaustive requirements, announce "AUTHZ EXPLOITATION COMPLETE" and stop.
 

--- a/apps/worker/prompts/exploit-injection.txt
+++ b/apps/worker/prompts/exploit-injection.txt
@@ -70,13 +70,13 @@ Remember: An unproven vulnerability is worse than no finding at all - it wastes 
 </login_instructions>
 
 <starting_context>
-- Your **actionable exploitation queue** is located at `deliverables/injection_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
+- Your **actionable exploitation queue** is located at `.shannon/deliverables/injection_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
 
 **INTELLIGENCE GATHERING PHASE (MANDATORY):**
 Before beginning exploitation, read these strategic intelligence files in order:
-1. `deliverables/pre_recon_deliverable.md` - Architecture overview, exact vulnerable code snippets, database details, authentication mechanisms
-2. `deliverables/recon_deliverable.md` - Complete API inventory, input vectors, code pointers with file:line references  
-3. `deliverables/injection_analysis_deliverable.md` - Strategic context from analysis specialist, WAF behavior, database technologies
+1. `.shannon/deliverables/pre_recon_deliverable.md` - Architecture overview, exact vulnerable code snippets, database details, authentication mechanisms
+2. `.shannon/deliverables/recon_deliverable.md` - Complete API inventory, input vectors, code pointers with file:line references
+3. `.shannon/deliverables/injection_analysis_deliverable.md` - Strategic context from analysis specialist, WAF behavior, database technologies
 
 **INTELLIGENCE-INFORMED EXPLOITATION:**
 - Use exact query or command structures provided in intelligence reports to construct precise payloads.
@@ -91,13 +91,13 @@ Before beginning exploitation, read these strategic intelligence files in order:
 
 **Phase Sequence:** VULN ANALYSIS (Complete) → **INJECTION EXPLOITATION (You)** → FINAL REPORT (next phase)
 
-**Your Input:** `deliverables/injection_exploitation_queue.json` (primary exploitation queue)
-**Your Output:** `deliverables/injection_exploitation_evidence.md` (exploitation evidence)
+**Your Input:** `.shannon/deliverables/injection_exploitation_queue.json` (primary exploitation queue)
+**Your Output:** `.shannon/deliverables/injection_exploitation_evidence.md` (exploitation evidence)
 
 **Supporting Intelligence:**
-- `deliverables/pre_recon_deliverable.md` (architecture & code context)  
-- `deliverables/recon_deliverable.md` (API inventory & input vectors)
-- `deliverables/injection_analysis_deliverable.md` (strategic intel)
+- `.shannon/deliverables/pre_recon_deliverable.md` (architecture & code context)
+- `.shannon/deliverables/recon_deliverable.md` (API inventory & input vectors)
+- `.shannon/deliverables/injection_analysis_deliverable.md` (strategic intel)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture and attack surfaces
@@ -139,7 +139,7 @@ Your primary goal is to achieve a definitive, evidence-backed conclusion for **e
 Your entire exploitation process will be managed through the TodoWrite tool. You MUST adhere to this process.
 
 **1. Initialization:**
-- Read the `deliverables/injection_exploitation_queue.json` file.
+- Read the `.shannon/deliverables/injection_exploitation_queue.json` file.
 - Use the TodoWrite tool to create tasks for each vulnerability in the queue.
 - Each task should include the vulnerability ID and the hypothesis to test.
     Example tasks:
@@ -347,7 +347,7 @@ First, synthesize all of your evidence into your specialist section and save it 
 Your section MUST use the following structure precisely:
 
 **Section Ordering & Format Requirements:**
-- Use the exact vulnerability IDs from `deliverables/injection_exploitation_queue.json`
+- Use the exact vulnerability IDs from `.shannon/deliverables/injection_exploitation_queue.json`
 - Within "Successfully Exploited" section: Order by severity of impact (most critical first)
 - Within "Potential" section: Order by confidence level (highest confidence first)
 
@@ -436,13 +436,13 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 1.  **Plan Completion:** ALL tasks for EVERY vulnerability in your todo list must be marked as completed using the TodoWrite tool. **No vulnerability or task can be left unaddressed.**
 2.  **Deliverable Generation:** The required deliverable must be successfully saved using the save-deliverable CLI tool:
     - **CHUNKED WRITING (MANDATORY):**
-      1. Use the **Write** tool to create `deliverables/injection_exploitation_evidence.md` with the title and first major section
+      1. Use the **Write** tool to create `.shannon/deliverables/injection_exploitation_evidence.md` with the title and first major section
       2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
       3. Repeat step 2 for all remaining sections
-      4. Run `save-deliverable` with `--type INJECTION_EVIDENCE --file-path "deliverables/injection_exploitation_evidence.md"`
+      4. Run `save-deliverable` with `--type INJECTION_EVIDENCE --file-path ".shannon/deliverables/injection_exploitation_evidence.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
-**CRITICAL WARNING:** Announcing completion before every item in `deliverables/injection_exploitation_queue.json` has been pursued to a final, evidence-backed conclusion (either successfully exploited or verified false positive) will be considered a mission failure. Superficial testing is not acceptable.
+**CRITICAL WARNING:** Announcing completion before every item in `.shannon/deliverables/injection_exploitation_queue.json` has been pursued to a final, evidence-backed conclusion (either successfully exploited or verified false positive) will be considered a mission failure. Superficial testing is not acceptable.
 
 ONLY AFTER fulfilling these exhaustive requirements, announce "INJECTION EXPLOITATION COMPLETE" and stop.
 

--- a/apps/worker/prompts/exploit-ssrf.txt
+++ b/apps/worker/prompts/exploit-ssrf.txt
@@ -93,13 +93,13 @@ After exhaustive bypass attempts, determine:
 </login_instructions>
 
 <starting_context>
-- Your **actionable exploitation queue** is located at `deliverables/ssrf_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
+- Your **actionable exploitation queue** is located at `.shannon/deliverables/ssrf_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
 
 **INTELLIGENCE GATHERING PHASE (MANDATORY):**
 Before beginning exploitation, read these strategic intelligence files in order:
-1.  `deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and network service details.
-2.  `deliverables/recon_deliverable.md` - Complete API inventory, service endpoints, and internal architecture maps.
-3.  `deliverables/ssrf_analysis_deliverable.md` - Strategic context from the SSRF analysis specialist, including notes on HTTP client usage, URL validation patterns, and request mechanisms.
+1.  `.shannon/deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and network service details.
+2.  `.shannon/deliverables/recon_deliverable.md` - Complete API inventory, service endpoints, and internal architecture maps.
+3.  `.shannon/deliverables/ssrf_analysis_deliverable.md` - Strategic context from the SSRF analysis specialist, including notes on HTTP client usage, URL validation patterns, and request mechanisms.
 
 - You will manage your work using the **TodoWrite tool** to track your exploitation tasks and progress. The todo list is your private workbench for organizing and tracking all exploitation attempts.
 </starting_context>
@@ -109,13 +109,13 @@ Before beginning exploitation, read these strategic intelligence files in order:
 
 **Phase Sequence:** VULN ANALYSIS (Complete) → **SSRF EXPLOITATION (You)** → FINAL REPORT (next phase)
 
-**Your Input:** `deliverables/ssrf_exploitation_queue.json` (primary exploitation queue)
-**Your Output:** `deliverables/ssrf_exploitation_evidence.md` (exploitation evidence)
+**Your Input:** `.shannon/deliverables/ssrf_exploitation_queue.json` (primary exploitation queue)
+**Your Output:** `.shannon/deliverables/ssrf_exploitation_evidence.md` (exploitation evidence)
 
 **Supporting Intelligence:**
-- `deliverables/pre_recon_deliverable.md` (architecture & network context)
-- `deliverables/recon_deliverable.md` (API inventory & service endpoints)
-- `deliverables/ssrf_analysis_deliverable.md` (strategic intel)
+- `.shannon/deliverables/pre_recon_deliverable.md` (architecture & network context)
+- `.shannon/deliverables/recon_deliverable.md` (API inventory & service endpoints)
+- `.shannon/deliverables/ssrf_analysis_deliverable.md` (strategic intel)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture and attack surfaces
@@ -176,7 +176,7 @@ Your primary goal is to achieve a definitive, evidence-backed conclusion for **e
 Your entire exploitation process will be managed through the TodoWrite tool. You MUST adhere to this process.
 
 **1. Initialization:**
-- Read `deliverables/ssrf_exploitation_queue.json`.
+- Read `.shannon/deliverables/ssrf_exploitation_queue.json`.
 - Use the TodoWrite tool to create tasks for each vulnerability in the queue.
 - Each task should include the vulnerability ID and the hypothesis to test.
     Example tasks:
@@ -398,7 +398,7 @@ When your attack plan is fully explored (all checkboxes are marked `[x]`), your 
 First, synthesize all evidence into your specialist section and save it using the save-deliverable CLI with --type SSRF_EVIDENCE. This section will be combined with other specialist reports to form the complete security assessment and MUST use the following structure:
 
 **Section Ordering & Format Requirements:**
-- Use the exact vulnerability IDs from `deliverables/ssrf_exploitation_queue.json`
+- Use the exact vulnerability IDs from `.shannon/deliverables/ssrf_exploitation_queue.json`
 - Within "Successfully Exploited" section: Order by severity of impact (most critical first)
 - Within "Potential" section: Order by confidence level (highest confidence first)
 
@@ -486,13 +486,13 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 	1. Plan Completion: ALL tasks in your todo list must be marked as completed using the TodoWrite tool.
 	2. Deliverable Generation: The required deliverable must be successfully saved using the save-deliverable CLI:
 	  - **CHUNKED WRITING (MANDATORY):**
-	    1. Use the **Write** tool to create `deliverables/ssrf_exploitation_evidence.md` with the title and first major section
+	    1. Use the **Write** tool to create `.shannon/deliverables/ssrf_exploitation_evidence.md` with the title and first major section
 	    2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
 	    3. Repeat step 2 for all remaining sections
-	    4. Run `save-deliverable` with `--type SSRF_EVIDENCE --file-path "deliverables/ssrf_exploitation_evidence.md"`
+	    4. Run `save-deliverable` with `--type SSRF_EVIDENCE --file-path ".shannon/deliverables/ssrf_exploitation_evidence.md"`
 	    **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
-CRITICAL WARNING: Announcing completion before every item in deliverables/ssrf_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
+CRITICAL WARNING: Announcing completion before every item in .shannon/deliverables/ssrf_exploitation_queue.json has been pursued to a final, evidence-backed conclusion will be considered a mission failure.
 
 ONLY AFTER fulfilling these exhaustive requirements, announce "SSRF EXPLOITATION COMPLETE" and stop.
 

--- a/apps/worker/prompts/exploit-xss.txt
+++ b/apps/worker/prompts/exploit-xss.txt
@@ -91,13 +91,13 @@ After exhaustive bypass attempts, determine:
 </login_instructions>
 
 <starting_context>
-- Your **actionable exploitation queue** is located at `deliverables/xss_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
+- Your **actionable exploitation queue** is located at `.shannon/deliverables/xss_exploitation_queue.json`. This is your to-do list, containing the precise targets identified by the analysis phase. You MUST process every vulnerability in this queue.
 
 **INTELLIGENCE GATHERING PHASE (MANDATORY):**
 Before beginning exploitation, read these strategic intelligence files in order:
-1.  `deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and critical file paths.
-2.  `deliverables/recon_deliverable.md` - Complete API inventory, input vectors, and data flow maps.
-3.  `deliverables/xss_analysis_deliverable.md` - Strategic context from the XSS analysis specialist, including notes on WAF behavior, CSP headers, and cookie flags.
+1.  `.shannon/deliverables/pre_recon_deliverable.md` - Architecture overview, technology stack, and critical file paths.
+2.  `.shannon/deliverables/recon_deliverable.md` - Complete API inventory, input vectors, and data flow maps.
+3.  `.shannon/deliverables/xss_analysis_deliverable.md` - Strategic context from the XSS analysis specialist, including notes on WAF behavior, CSP headers, and cookie flags.
 
 **INTELLIGENCE-INFORMED EXPLOITATION:**
 - Use the `render_context` and `mismatch_reason` from the analysis queue to craft precise initial payloads.
@@ -111,13 +111,13 @@ Before beginning exploitation, read these strategic intelligence files in order:
 
 **Phase Sequence:** VULN ANALYSIS (Complete) → **XSS EXPLOITATION (You)** → FINAL REPORT (next phase)
 
-**Your Input:** `deliverables/xss_exploitation_queue.json` (primary exploitation queue)
-**Your Output:** `deliverables/xss_exploitation_evidence.md` (exploitation evidence)
+**Your Input:** `.shannon/deliverables/xss_exploitation_queue.json` (primary exploitation queue)
+**Your Output:** `.shannon/deliverables/xss_exploitation_evidence.md` (exploitation evidence)
 
 **Supporting Intelligence:**
-- `deliverables/pre_recon_deliverable.md` (architecture & code context)
-- `deliverables/recon_deliverable.md` (API inventory & input vectors)  
-- `deliverables/xss_analysis_deliverable.md` (strategic intel)
+- `.shannon/deliverables/pre_recon_deliverable.md` (architecture & code context)
+- `.shannon/deliverables/recon_deliverable.md` (API inventory & input vectors)
+- `.shannon/deliverables/xss_analysis_deliverable.md` (strategic intel)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture and attack surfaces
@@ -183,7 +183,7 @@ For **every single vulnerability** in your queue, systematically work through th
 **Goal:** Set up tracking and understand the pre-analyzed vulnerabilities.
 
 **Actions:**
-- Read `deliverables/xss_exploitation_queue.json` to get your targets with their complete graph analysis
+- Read `.shannon/deliverables/xss_exploitation_queue.json` to get your targets with their complete graph analysis
 - Use **TodoWrite tool** to create a todo for each vulnerability with its graph characteristics
   - Example: "XSS-VULN-01: Exploit Reflected XSS in /search?q= (source: URL param → no sanitization → innerHTML sink)"
 - Study the provided intelligence for each vulnerability:
@@ -331,7 +331,7 @@ First, synthesize all of your evidence into your specialist section and save it 
 Your section MUST use the following structure precisely:
 
 **Section Ordering & Format Requirements:**
-- Use the exact vulnerability IDs from `deliverables/xss_exploitation_queue.json`
+- Use the exact vulnerability IDs from `.shannon/deliverables/xss_exploitation_queue.json`
 - Within "Successfully Exploited" section: Order by severity of impact (most critical first)
 - Within "Potential" section: Order by confidence level (highest confidence first)
 
@@ -426,13 +426,13 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 - Todo List Completion: ALL vulnerabilities from the exploitation queue must have been processed and marked as completed in your todo list.
 - Deliverable Generation: The required deliverable must be successfully saved using the save-deliverable CLI tool:
   - **CHUNKED WRITING (MANDATORY):**
-    1. Use the **Write** tool to create `deliverables/xss_exploitation_evidence.md` with the title and first major section
+    1. Use the **Write** tool to create `.shannon/deliverables/xss_exploitation_evidence.md` with the title and first major section
     2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
     3. Repeat step 2 for all remaining sections
-    4. Run `save-deliverable` with `--type XSS_EVIDENCE --file-path "deliverables/xss_exploitation_evidence.md"`
+    4. Run `save-deliverable` with `--type XSS_EVIDENCE --file-path ".shannon/deliverables/xss_exploitation_evidence.md"`
     **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
-**CRITICAL WARNING:** Announcing completion before every item in `deliverables/xss_exploitation_queue.json` has been pursued to a final, evidence-backed conclusion (either successfully exploited or verified false positive) will be considered a mission failure. Superficial testing is not acceptable.
+**CRITICAL WARNING:** Announcing completion before every item in `.shannon/deliverables/xss_exploitation_queue.json` has been pursued to a final, evidence-backed conclusion (either successfully exploited or verified false positive) will be considered a mission failure. Superficial testing is not acceptable.
 
 ONLY AFTER both plan completion AND successful deliverable generation, announce "XSS EXPLOITATION COMPLETE" and stop.
 

--- a/apps/worker/prompts/pipeline-testing/exploit-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-auth.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/auth-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/auth-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-auth.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/auth-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/scratchpad/auth-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-auth.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/auth-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/auth-exploit-test.png"
    ```
 
 3. Log the test results:
@@ -26,7 +26,7 @@ Run the save-deliverable CLI:
 save-deliverable --type AUTH_EVIDENCE --content '# Authentication Exploitation Evidence (Pipeline Test)\n\n**Playwright Session:** {{PLAYWRIGHT_SESSION}}\n**Test Site:** https://example.com\n**Screenshot:** auth-exploit-test.png\n**Status:** Browser isolation test successful\n\n## Exploitation Results\n- **Target:** Test authentication vulnerability\n- **Method:** Authentication bypass via parameter manipulation\n- **Evidence:** Successfully bypassed login using admin=true parameter\n- **Impact:** Demonstrated unauthorized access to protected resources\n- **Proof:** Pipeline testing mode - simulated successful exploitation\n\n## Technical Details\n- **Vulnerability ID:** AUTH-VULN-01\n- **Exploitation Status:** Simulated Success (Pipeline Test)\n- **Session:** {{PLAYWRIGHT_SESSION}}\n- **Attack Vector:** Parameter-based authentication bypass\n- **Bypass Method:** URL parameter manipulation'
 ```
 
-This will automatically create `deliverables/auth_exploitation_evidence.md`.
+This will automatically create `.shannon/deliverables/auth_exploitation_evidence.md`.
 
 ### Step 3: Verify Session Isolation
 This agent should be using {{PLAYWRIGHT_SESSION}} and navigating to example.com independently of other parallel exploitation agents.

--- a/apps/worker/prompts/pipeline-testing/exploit-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-auth.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 ## 🧪 Pipeline Testing: Session Isolation Test for Authentication Exploitation Agent
 
 **Playwright Session:** Using session `{{PLAYWRIGHT_SESSION}}` for browser automation testing.
@@ -10,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "auth-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/auth-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-authz.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 ## 🧪 Pipeline Testing: Session Isolation Test for Authorization Exploitation Agent
 
 **Playwright Session:** Using session `{{PLAYWRIGHT_SESSION}}` for browser automation testing.
@@ -10,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "authz-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/authz-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-authz.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/authz-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/authz-exploit-test.png"
    ```
 
 3. Log the test results:
@@ -26,7 +26,7 @@ Run the save-deliverable CLI:
 save-deliverable --type AUTHZ_EVIDENCE --content '# Authorization Exploitation Evidence (Pipeline Test)\n\n**Playwright Session:** {{PLAYWRIGHT_SESSION}}\n**Test Site:** https://example.com\n**Screenshot:** authz-exploit-test.png\n**Status:** Browser isolation test successful\n\n## Exploitation Results\n- **Target:** Test authorization vulnerability\n- **Method:** Privilege escalation via direct object reference\n- **Evidence:** Successfully accessed admin panel with user-level privileges\n- **Impact:** Demonstrated unauthorized access to privileged functionality\n- **Proof:** Pipeline testing mode - simulated successful exploitation\n\n## Technical Details\n- **Vulnerability ID:** AUTHZ-VULN-01\n- **Exploitation Status:** Simulated Success (Pipeline Test)\n- **Session:** {{PLAYWRIGHT_SESSION}}\n- **Attack Vector:** Insecure Direct Object Reference (IDOR)\n- **Escalation Method:** User ID manipulation in API calls'
 ```
 
-This will automatically create `deliverables/authz_exploitation_evidence.md`.
+This will automatically create `.shannon/deliverables/authz_exploitation_evidence.md`.
 
 ### Step 3: Verify Session Isolation
 This agent should be using {{PLAYWRIGHT_SESSION}} and navigating to example.com independently of other parallel exploitation agents.

--- a/apps/worker/prompts/pipeline-testing/exploit-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-authz.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/authz-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/scratchpad/authz-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-authz.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/authz-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/authz-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-injection.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/injection-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/scratchpad/injection-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-injection.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 ## 🧪 Pipeline Testing: Session Isolation Test for Injection Exploitation Agent
 
 **Playwright Session:** Using session `{{PLAYWRIGHT_SESSION}}` for browser automation testing.
@@ -10,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "injection-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/injection-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-injection.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/injection-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/injection-exploit-test.png"
    ```
 
 3. Log the test results:
@@ -26,7 +26,7 @@ Run the save-deliverable CLI:
 save-deliverable --type INJECTION_EVIDENCE --content '# Injection Exploitation Evidence (Pipeline Test)\n\n**Playwright Session:** {{PLAYWRIGHT_SESSION}}\n**Test Site:** https://example.com\n**Screenshot:** injection-exploit-test.png\n**Status:** Browser isolation test successful\n\n## Exploitation Results\n- **Target:** Test injection vulnerability\n- **Vulnerability Type:** SQLi | CommandInjection | LFI | RFI | SSTI | PathTraversal | InsecureDeserialization\n- **Method:** [Type-specific exploitation method]\n- **Evidence:** Successfully executed test payload\n- **Impact:** Demonstrated ability to manipulate [database queries | system commands | file system | template engine | deserialization]\n- **Proof:** Pipeline testing mode - simulated successful exploitation\n\n## Technical Details\n- **Vulnerability ID:** INJ-VULN-XX\n- **Exploitation Status:** Simulated Success (Pipeline Test)\n- **Session:** {{PLAYWRIGHT_SESSION}}'
 ```
 
-This will automatically create `deliverables/injection_exploitation_evidence.md`.
+This will automatically create `.shannon/deliverables/injection_exploitation_evidence.md`.
 
 ### Step 3: Verify Session Isolation
 This agent should be using {{PLAYWRIGHT_SESSION}} and navigating to example.com independently of other parallel exploitation agents.

--- a/apps/worker/prompts/pipeline-testing/exploit-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-injection.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/injection-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/injection-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/ssrf-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/ssrf-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/ssrf-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/scratchpad/ssrf-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 ## 🧪 Pipeline Testing: Session Isolation Test for SSRF Exploitation Agent
 
 **Playwright Session:** Using session `{{PLAYWRIGHT_SESSION}}` for browser automation testing.
@@ -10,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "ssrf-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/ssrf-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-ssrf.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/ssrf-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/ssrf-exploit-test.png"
    ```
 
 3. Log the test results:
@@ -26,7 +26,7 @@ Run the save-deliverable CLI:
 save-deliverable --type SSRF_EVIDENCE --content '# SSRF Exploitation Evidence (Pipeline Test)\n\n**Playwright Session:** {{PLAYWRIGHT_SESSION}}\n**Test Site:** https://example.com\n**Screenshot:** ssrf-exploit-test.png\n**Status:** Browser isolation test successful\n\n## Exploitation Results\n- **Target:** Test SSRF vulnerability\n- **Method:** Server-Side Request Forgery via URL parameter\n- **Evidence:** Successfully forced server to make request to internal network\n- **Impact:** Demonstrated access to internal services and potential data exfiltration\n- **Proof:** Pipeline testing mode - simulated successful exploitation\n\n## Technical Details\n- **Vulnerability ID:** SSRF-VULN-01\n- **Exploitation Status:** Simulated Success (Pipeline Test)\n- **Session:** {{PLAYWRIGHT_SESSION}}\n- **Attack Vector:** URL parameter manipulation\n- **Target:** Internal network services (localhost:8080)'
 ```
 
-This will automatically create `deliverables/ssrf_exploitation_evidence.md`.
+This will automatically create `.shannon/deliverables/ssrf_exploitation_evidence.md`.
 
 ### Step 3: Verify Session Isolation
 This agent should be using {{PLAYWRIGHT_SESSION}} and navigating to example.com independently of other parallel exploitation agents.

--- a/apps/worker/prompts/pipeline-testing/exploit-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-xss.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/xss-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/scratchpad/xss-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-xss.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 ## 🧪 Pipeline Testing: Session Isolation Test for XSS Exploitation Agent
 
 **Playwright Session:** Using session `{{PLAYWRIGHT_SESSION}}` for browser automation testing.
@@ -10,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "xss-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/xss-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-xss.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "playground/xss-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/xss-exploit-test.png"
    ```
 
 3. Log the test results:

--- a/apps/worker/prompts/pipeline-testing/exploit-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/exploit-xss.txt
@@ -12,7 +12,7 @@
 
 2. Take a screenshot to prove isolation:
    ```
-   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/playground/xss-exploit-test.png"
+   playwright-cli -s={{PLAYWRIGHT_SESSION}} screenshot --filename "{{REPO_PATH}}/.shannon/playground/xss-exploit-test.png"
    ```
 
 3. Log the test results:
@@ -26,7 +26,7 @@ Run the save-deliverable CLI:
 save-deliverable --type XSS_EVIDENCE --content '# XSS Exploitation Evidence (Pipeline Test)\n\n**Playwright Session:** {{PLAYWRIGHT_SESSION}}\n**Test Site:** https://example.com\n**Screenshot:** xss-exploit-test.png\n**Status:** Browser isolation test successful\n\n## Exploitation Results\n- **Target:** Test XSS vulnerability\n- **Method:** Reflected XSS via search parameter\n- **Evidence:** Successfully executed payload `<script>alert('\''XSS'\'')</script>`\n- **Impact:** Demonstrated JavaScript code execution in user context\n- **Proof:** Pipeline testing mode - simulated successful exploitation\n\n## Technical Details\n- **Vulnerability ID:** XSS-VULN-01\n- **Exploitation Status:** Simulated Success (Pipeline Test)\n- **Session:** {{PLAYWRIGHT_SESSION}}\n- **Attack Vector:** Reflected XSS in search functionality'
 ```
 
-This will automatically create `deliverables/xss_exploitation_evidence.md`.
+This will automatically create `.shannon/deliverables/xss_exploitation_evidence.md`.
 
 ### Step 3: Verify Session Isolation
 This agent should be using {{PLAYWRIGHT_SESSION}} and navigating to example.com independently of other parallel exploitation agents.

--- a/apps/worker/prompts/pipeline-testing/pre-recon-code.txt
+++ b/apps/worker/prompts/pipeline-testing/pre-recon-code.txt
@@ -1,1 +1,3 @@
+@include(shared/_filesystem.txt)
+
 Run: `save-deliverable --type CODE_ANALYSIS --content 'Pre-recon analysis complete'`. Then say "Done".

--- a/apps/worker/prompts/pipeline-testing/recon.txt
+++ b/apps/worker/prompts/pipeline-testing/recon.txt
@@ -1,1 +1,3 @@
+@include(shared/_filesystem.txt)
+
 Run: `save-deliverable --type RECON --content 'Reconnaissance analysis complete'`. Then say "Done".

--- a/apps/worker/prompts/pipeline-testing/report-executive.txt
+++ b/apps/worker/prompts/pipeline-testing/report-executive.txt
@@ -1,1 +1,3 @@
+@include(shared/_filesystem.txt)
+
 Read `deliverables/comprehensive_security_assessment_report.md`, prepend "# Security Assessment Report\n\n**Target:** {{WEB_URL}}\n\n" to the content, and save it back. Say "Done".

--- a/apps/worker/prompts/pipeline-testing/report-executive.txt
+++ b/apps/worker/prompts/pipeline-testing/report-executive.txt
@@ -1,3 +1,3 @@
 @include(shared/_filesystem.txt)
 
-Read `deliverables/comprehensive_security_assessment_report.md`, prepend "# Security Assessment Report\n\n**Target:** {{WEB_URL}}\n\n" to the content, and save it back. Say "Done".
+Read `.shannon/deliverables/comprehensive_security_assessment_report.md`, prepend "# Security Assessment Report\n\n**Target:** {{WEB_URL}}\n\n" to the content, and save it back. Say "Done".

--- a/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
+++ b/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
@@ -1,0 +1,4 @@
+Filesystem:
+- Source code repository (read only)
+- `deliverables/` - Final reports and analysis output (read-write)
+- `playground/` - Scratch work (read-write)

--- a/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
+++ b/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
@@ -1,4 +1,4 @@
 Filesystem:
-- Source code repository (read only)
-- `deliverables/` - Final reports and analysis output (read-write)
-- `playground/` - Scratch work (read-write)
+- {{REPO_PATH}}/ (read only)
+- {{REPO_PATH}}/deliverables/ (read-write)
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts

--- a/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
+++ b/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
@@ -1,4 +1,4 @@
 Filesystem:
 - {{REPO_PATH}}/ (read only)
-- {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/deliverables/ (read-write)
+- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.

--- a/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
+++ b/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
@@ -1,4 +1,4 @@
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.

--- a/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
+++ b/apps/worker/prompts/pipeline-testing/shared/_filesystem.txt
@@ -1,4 +1,4 @@
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/.shannon/deliverables/ (read-write)
-- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/scratchpad/ (read-write) - screenshots, scripts, scratch work, etc.

--- a/apps/worker/prompts/pipeline-testing/vuln-auth.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-auth.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 Please complete these tasks using your CLI tools:
 
 1. Navigate to https://example.net and take a screenshot:

--- a/apps/worker/prompts/pipeline-testing/vuln-authz.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-authz.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 Please complete these tasks using your CLI tools:
 
 1. Navigate to https://jsonplaceholder.typicode.com and take a screenshot:

--- a/apps/worker/prompts/pipeline-testing/vuln-injection.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-injection.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 Please complete these tasks using your CLI tools:
 
 1. Navigate to https://example.com and take a screenshot:

--- a/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-ssrf.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 Please complete these tasks using your CLI tools:
 
 1. Navigate to https://httpbin.org and take a screenshot:

--- a/apps/worker/prompts/pipeline-testing/vuln-xss.txt
+++ b/apps/worker/prompts/pipeline-testing/vuln-xss.txt
@@ -1,3 +1,5 @@
+@include(shared/_filesystem.txt)
+
 Please complete these tasks using your CLI tools:
 
 1. Navigate to https://example.org and take a screenshot:

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -13,7 +13,7 @@ Objective: Your task is to analyze the provided source code to generate a securi
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/.shannon/deliverables/ (read-write)
-- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/scratchpad/ (read-write) - screenshots, scripts, scratch work, etc.
 
 **CRITICAL INSTRUCTIONS:**
 - Base your analysis SOLELY on the provided source code. Do not invent services or infer functionality that is not present.

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -8,7 +8,12 @@ Objective: Your task is to analyze the provided source code to generate a securi
 - **Sole Source Code Access:** You are the ONLY agent in the workflow with complete source code access. If you miss a security component, authentication endpoint, or attack surface element, no other agent can discover it. The thoroughness of your analysis directly determines the success of the entire engagement.
 - **Code is Ground Truth:** Your analysis must be rooted in actual source code, not assumptions or external documentation. Every security claim must be backed by specific file paths and code examples. You are establishing the technical facts that all other agents will use.
 
-**WORKING CONTEXT:** You are currently in the root directory of the target codebase to analyze. The source code repository is (read only). `deliverables/` is (read-write) for final reports. `playground/` is for scratch work (read-write).
+**WORKING CONTEXT:** You are currently in the root directory of the target codebase to analyze.
+
+Filesystem:
+- {{REPO_PATH}}/ (read only)
+- {{REPO_PATH}}/deliverables/ (read-write)
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
 
 **CRITICAL INSTRUCTIONS:**
 - Base your analysis SOLELY on the provided source code. Do not invent services or infer functionality that is not present.

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -128,8 +128,8 @@ After Phase 1 completes, launch all three vulnerability-focused agents in parall
 - Resolve conflicts and eliminate duplicates
 - Generate the final structured markdown report
 - **Schema Management**: Using schemas identified by the Entry Point Mapper Agent:
-  - Create the `outputs/schemas/` directory using mkdir -p
-  - Copy all discovered schema files to `outputs/schemas/` with descriptive names
+  - Create the `deliverables/schemas/` directory using mkdir -p
+  - Copy all discovered schema files to `deliverables/schemas/` with descriptive names
   - Include schema locations in your attack surface analysis
 - **CHUNKED WRITING (MANDATORY):**
   1. Use the **Write** tool to create `deliverables/code_analysis_deliverable.md` with the title and first major section
@@ -395,7 +395,7 @@ A component is **out-of-scope** if it **cannot** be invoked through the running 
 
 2. **Deliverable Generation:** The following files must be successfully created:
    - `deliverables/code_analysis_deliverable.md` (via `save-deliverable` with `--file-path`, not inline `--content`)
-   - `outputs/schemas/` directory with all discovered schema files copied (if any schemas found)
+   - `deliverables/schemas/` directory with all discovered schema files copied (if any schemas found)
 
 3. **TodoWrite Completion:** All tasks in your todo list must be marked as completed
 

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -13,7 +13,7 @@ Objective: Your task is to analyze the provided source code to generate a securi
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
 
 **CRITICAL INSTRUCTIONS:**
 - Base your analysis SOLELY on the provided source code. Do not invent services or infer functionality that is not present.

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -8,7 +8,7 @@ Objective: Your task is to analyze the provided source code to generate a securi
 - **Sole Source Code Access:** You are the ONLY agent in the workflow with complete source code access. If you miss a security component, authentication endpoint, or attack surface element, no other agent can discover it. The thoroughness of your analysis directly determines the success of the entire engagement.
 - **Code is Ground Truth:** Your analysis must be rooted in actual source code, not assumptions or external documentation. Every security claim must be backed by specific file paths and code examples. You are establishing the technical facts that all other agents will use.
 
-**WORKING CONTEXT:** You are currently in the root directory of the target codebase to analyze.
+**WORKING CONTEXT:** You are currently in the root directory of the target codebase to analyze. The source code repository is (read only). `deliverables/` is (read-write) for final reports. `playground/` is for scratch work (read-write).
 
 **CRITICAL INSTRUCTIONS:**
 - Base your analysis SOLELY on the provided source code. Do not invent services or infer functionality that is not present.

--- a/apps/worker/prompts/pre-recon-code.txt
+++ b/apps/worker/prompts/pre-recon-code.txt
@@ -12,8 +12,8 @@ Objective: Your task is to analyze the provided source code to generate a securi
 
 Filesystem:
 - {{REPO_PATH}}/ (read only)
-- {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/deliverables/ (read-write)
+- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
 
 **CRITICAL INSTRUCTIONS:**
 - Base your analysis SOLELY on the provided source code. Do not invent services or infer functionality that is not present.
@@ -37,7 +37,7 @@ Read `.gitignore` and run `git ls-files --others --ignored --exclude-standard --
 **Phase Sequence:** **PRE-RECON (You)** → RECON → VULN ANALYSIS (5 agents) → EXPLOITATION (5 agents) → REPORTING
 
 **Your Input:** External scan results from pre-recon tools (nmap, subfinder, whatweb)
-**Your Output:** `deliverables/code_analysis_deliverable.md` (feeds all subsequent analysis phases)
+**Your Output:** `.shannon/deliverables/code_analysis_deliverable.md` (feeds all subsequent analysis phases)
 **Shared Intelligence:** You create the foundational intelligence baseline that all other agents depend on
 
 **WHAT HAPPENED BEFORE YOU:**
@@ -133,14 +133,14 @@ After Phase 1 completes, launch all three vulnerability-focused agents in parall
 - Resolve conflicts and eliminate duplicates
 - Generate the final structured markdown report
 - **Schema Management**: Using schemas identified by the Entry Point Mapper Agent:
-  - Create the `deliverables/schemas/` directory using mkdir -p
-  - Copy all discovered schema files to `deliverables/schemas/` with descriptive names
+  - Create the `.shannon/deliverables/schemas/` directory using mkdir -p
+  - Copy all discovered schema files to `.shannon/deliverables/schemas/` with descriptive names
   - Include schema locations in your attack surface analysis
 - **CHUNKED WRITING (MANDATORY):**
-  1. Use the **Write** tool to create `deliverables/code_analysis_deliverable.md` with the title and first major section
+  1. Use the **Write** tool to create `.shannon/deliverables/code_analysis_deliverable.md` with the title and first major section
   2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
   3. Repeat step 2 for all remaining sections
-  4. Run `save-deliverable` with `--type CODE_ANALYSIS --file-path "deliverables/code_analysis_deliverable.md"`
+  4. Run `save-deliverable` with `--type CODE_ANALYSIS --file-path ".shannon/deliverables/code_analysis_deliverable.md"`
 - **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
 **EXECUTION PATTERN:**
@@ -399,8 +399,8 @@ A component is **out-of-scope** if it **cannot** be invoked through the running 
    - Phase 3: Synthesis and report generation completed
 
 2. **Deliverable Generation:** The following files must be successfully created:
-   - `deliverables/code_analysis_deliverable.md` (via `save-deliverable` with `--file-path`, not inline `--content`)
-   - `deliverables/schemas/` directory with all discovered schema files copied (if any schemas found)
+   - `.shannon/deliverables/code_analysis_deliverable.md` (via `save-deliverable` with `--file-path`, not inline `--content`)
+   - `.shannon/deliverables/schemas/` directory with all discovered schema files copied (if any schemas found)
 
 3. **TodoWrite Completion:** All tasks in your todo list must be marked as completed
 

--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -15,9 +15,9 @@ URL: {{WEB_URL}}
 {{DESCRIPTION}}
 
 Filesystem:
-- Source code repository (read only)
-- `deliverables/` - Final reports and analysis output (read-write)
-- `playground/` - Scratch work (read-write)
+- {{REPO_PATH}}/ (read only)
+- {{REPO_PATH}}/deliverables/ (read-write)
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
 </target>
 
 <rules>

--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -17,7 +17,7 @@ URL: {{WEB_URL}}
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/.shannon/deliverables/ (read-write)
-- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/scratchpad/ (read-write) - screenshots, scripts, scratch work, etc.
 </target>
 
 <rules>

--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -17,7 +17,7 @@ URL: {{WEB_URL}}
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
 </target>
 
 <rules>

--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -7,7 +7,7 @@ Your goal is to create a comprehensive, structured map of the application's atta
 </objective>
 
 <starting_context>
-Your analysis must begin by reading and fully comprehending the initial intelligence report located at `deliverables/pre_recon_deliverable.md`. This file contains the output of initial nmap, subfinder, whatweb, and code analysis scans. This is your only starting information.
+Your analysis must begin by reading and fully comprehending the initial intelligence report located at `.shannon/deliverables/pre_recon_deliverable.md`. This file contains the output of initial nmap, subfinder, whatweb, and code analysis scans. This is your only starting information.
 </starting_context>
 
 <target>
@@ -16,8 +16,8 @@ URL: {{WEB_URL}}
 
 Filesystem:
 - {{REPO_PATH}}/ (read only)
-- {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/deliverables/ (read-write)
+- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
 </target>
 
 <rules>
@@ -80,8 +80,8 @@ Please use these tools for the following use cases:
 
 **Phase Sequence:** PRE-RECON (Complete) → **RECONNAISSANCE (You)** → VULN ANALYSIS (5 agents) → EXPLOITATION (5 agents) → FINAL REPORT (next phase)
 
-**Your Input:** `deliverables/pre_recon_deliverable.md` (external scan data, initial code analysis)
-**Your Output:** `deliverables/recon_deliverable.md` (comprehensive attack surface map)
+**Your Input:** `.shannon/deliverables/pre_recon_deliverable.md` (external scan data, initial code analysis)
+**Your Output:** `.shannon/deliverables/recon_deliverable.md` (comprehensive attack surface map)
 **Shared Intelligence:** None (you are the first analysis specialist)
 
 **WHAT HAPPENED BEFORE YOU:**
@@ -111,7 +111,7 @@ You are the **Attack Surface Architect** - building the foundational intelligenc
 You must follow this methodical four-step process:
 
 1.  **Synthesize Initial Data:**
-    - Read the entire `deliverables/pre_recon_deliverable.md`.
+    - Read the entire `.shannon/deliverables/pre_recon_deliverable.md`.
     - In your thoughts, create a preliminary list of known technologies, subdomains, open ports, and key code modules.
 
 2.  **Interactive Application Exploration:**
@@ -372,10 +372,10 @@ CRITICAL: Only include sources tracing to dangerous sinks (shell, DB, file ops, 
 <conclusion_trigger>
 **DELIVERABLE SAVING:**
 1. **CHUNKED WRITING (MANDATORY):**
-   - Use the **Write** tool to create `deliverables/recon_deliverable.md` with the title and first major section
+   - Use the **Write** tool to create `.shannon/deliverables/recon_deliverable.md` with the title and first major section
    - Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
    - Repeat for all remaining sections
-2. Run `save-deliverable` with `--type RECON --file-path "deliverables/recon_deliverable.md"`
+2. Run `save-deliverable` with `--type RECON --file-path ".shannon/deliverables/recon_deliverable.md"`
 
 **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations. Do NOT pass your report as inline `--content` to save-deliverable — always use `--file-path`.
 

--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -13,6 +13,11 @@ Your analysis must begin by reading and fully comprehending the initial intellig
 <target>
 URL: {{WEB_URL}}
 {{DESCRIPTION}}
+
+Filesystem:
+- Source code repository (read only)
+- `deliverables/` - Final reports and analysis output (read-write)
+- `playground/` - Scratch work (read-write)
 </target>
 
 <rules>

--- a/apps/worker/prompts/report-executive.txt
+++ b/apps/worker/prompts/report-executive.txt
@@ -22,6 +22,11 @@ IMPORTANT: You are MODIFYING an existing file, not creating a new one.
 <target>
 URL: {{WEB_URL}}
 {{DESCRIPTION}}
+
+Filesystem:
+- Source code repository (read only)
+- `deliverables/` - Final reports and analysis output (read-write)
+- `playground/` - Scratch work (read-write)
 </target>
 
 <context>

--- a/apps/worker/prompts/report-executive.txt
+++ b/apps/worker/prompts/report-executive.txt
@@ -26,7 +26,7 @@ URL: {{WEB_URL}}
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/.shannon/deliverables/ (read-write)
-- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/scratchpad/ (read-write) - screenshots, scripts, scratch work, etc.
 </target>
 
 <context>

--- a/apps/worker/prompts/report-executive.txt
+++ b/apps/worker/prompts/report-executive.txt
@@ -26,7 +26,7 @@ URL: {{WEB_URL}}
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
 </target>
 
 <context>

--- a/apps/worker/prompts/report-executive.txt
+++ b/apps/worker/prompts/report-executive.txt
@@ -25,8 +25,8 @@ URL: {{WEB_URL}}
 
 Filesystem:
 - {{REPO_PATH}}/ (read only)
-- {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/deliverables/ (read-write)
+- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
 </target>
 
 <context>
@@ -36,13 +36,13 @@ Authentication Context:
 
 <input_files>
 You will analyze the following deliverable files:
-- `deliverables/pre_recon_deliverable.md` - Initial reconnaissance and technology stack
-- `deliverables/recon_deliverable.md` - Attack surface mapping and endpoint discovery
-- `deliverables/comprehensive_security_assessment_report.md` - The already-concatenated report that you will modify
+- `.shannon/deliverables/pre_recon_deliverable.md` - Initial reconnaissance and technology stack
+- `.shannon/deliverables/recon_deliverable.md` - Attack surface mapping and endpoint discovery
+- `.shannon/deliverables/comprehensive_security_assessment_report.md` - The already-concatenated report that you will modify
 </input_files>
 
 <deliverable_instructions>
-MODIFY the existing file `deliverables/comprehensive_security_assessment_report.md` by:
+MODIFY the existing file `.shannon/deliverables/comprehensive_security_assessment_report.md` by:
 
 1. ADDING these sections at the top:
 
@@ -103,7 +103,7 @@ IMPORTANT: Do NOT reorder the existing exploitation evidence sections. Maintain 
    - Executive Summary: Technical overview with actionable findings for engineering leaders
    - Network Reconnaissance: Focus on security-relevant discoveries from automated scans
 
-3. Clean the exploitation evidence sections from `comprehensive_security_assessment_report.md` by applying these rules:
+3. Clean the exploitation evidence sections from `.shannon/deliverables/comprehensive_security_assessment_report.md` by applying these rules:
    - KEEP these specific section headings:
      NOTE: these sections will contain vulnerability lists with IDs matching pattern `### [TYPE]-VULN-[NUMBER]`
      * `# [Type] Exploitation Evidence`
@@ -124,8 +124,8 @@ IMPORTANT: Do NOT reorder the existing exploitation evidence sections. Maintain 
 4. Combine the content:
    - Place the Executive Summary and Network Reconnaissance sections at the top
    - Follow with the cleaned exploitation evidence sections
-   - Save as the modified `comprehensive_security_assessment_report.md`
+   - Save as the modified `.shannon/deliverables/comprehensive_security_assessment_report.md`
 
-CRITICAL: You are modifying the existing concatenated report IN-PLACE, not creating a separate file.
+CRITICAL: You are modifying the existing concatenated report at `.shannon/deliverables/comprehensive_security_assessment_report.md` IN-PLACE, not creating a separate file.
 </instructions>
 

--- a/apps/worker/prompts/report-executive.txt
+++ b/apps/worker/prompts/report-executive.txt
@@ -24,9 +24,9 @@ URL: {{WEB_URL}}
 {{DESCRIPTION}}
 
 Filesystem:
-- Source code repository (read only)
-- `deliverables/` - Final reports and analysis output (read-write)
-- `playground/` - Scratch work (read-write)
+- {{REPO_PATH}}/ (read only)
+- {{REPO_PATH}}/deliverables/ (read-write)
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
 </target>
 
 <context>

--- a/apps/worker/prompts/shared/_target.txt
+++ b/apps/worker/prompts/shared/_target.txt
@@ -1,1 +1,6 @@
 URL: {{WEB_URL}}
+
+Filesystem:
+- Source code repository (read only)
+- `deliverables/` - Final reports and analysis output (read-write)
+- `playground/` - Scratch work (read-write)

--- a/apps/worker/prompts/shared/_target.txt
+++ b/apps/worker/prompts/shared/_target.txt
@@ -3,4 +3,4 @@ URL: {{WEB_URL}}
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.

--- a/apps/worker/prompts/shared/_target.txt
+++ b/apps/worker/prompts/shared/_target.txt
@@ -3,4 +3,4 @@ URL: {{WEB_URL}}
 Filesystem:
 - {{REPO_PATH}}/ (read only)
 - {{REPO_PATH}}/.shannon/deliverables/ (read-write)
-- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/scratchpad/ (read-write) - screenshots, scripts, scratch work, etc.

--- a/apps/worker/prompts/shared/_target.txt
+++ b/apps/worker/prompts/shared/_target.txt
@@ -2,5 +2,5 @@ URL: {{WEB_URL}}
 
 Filesystem:
 - {{REPO_PATH}}/ (read only)
-- {{REPO_PATH}}/deliverables/ (read-write)
-- {{REPO_PATH}}/playground/ (read-write) - screenshots, scripts, scratch work, etc.
+- {{REPO_PATH}}/.shannon/deliverables/ (read-write)
+- {{REPO_PATH}}/.shannon/playground/ (read-write) - screenshots, scripts, scratch work, etc.

--- a/apps/worker/prompts/shared/_target.txt
+++ b/apps/worker/prompts/shared/_target.txt
@@ -1,6 +1,6 @@
 URL: {{WEB_URL}}
 
 Filesystem:
-- Source code repository (read only)
-- `deliverables/` - Final reports and analysis output (read-write)
-- `playground/` - Scratch work (read-write)
+- {{REPO_PATH}}/ (read only)
+- {{REPO_PATH}}/deliverables/ (read-write)
+- {{REPO_PATH}}/playground/ (read-write) - screenshots, scratch work, temporary scripts

--- a/apps/worker/prompts/vuln-auth.txt
+++ b/apps/worker/prompts/vuln-auth.txt
@@ -33,7 +33,7 @@ Success criterion: A complete, code-backed analysis of every potential authentic
 </critical>
 
 <starting_context>
-- Your primary source of truth for the application's structure is the reconnaissance report located at `deliverables/recon_deliverable.md`. You must derive your list of testable endpoints and roles from this file.
+- Your primary source of truth for the application's structure is the reconnaissance report located at `.shannon/deliverables/recon_deliverable.md`. You must derive your list of testable endpoints and roles from this file.
 </starting_context>
 
 <system_architecture>
@@ -41,8 +41,8 @@ Success criterion: A complete, code-backed analysis of every potential authentic
 
 **Phase Sequence:** RECON (Complete) → **AUTH ANALYSIS (You)** → EXPLOITATION (next phase)
 
-**Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/auth_analysis_deliverable.md` (analysis report for exploitation phase)
+**Your Input:** `.shannon/deliverables/recon_deliverable.md`, `.shannon/deliverables/pre_recon_deliverable.md` (reconnaissance findings)
+**Your Output:** `.shannon/deliverables/auth_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, endpoints, and data flows
@@ -114,7 +114,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 # White-Box Vulnerability Analysis Procedure: Broken Authentication (AuthN-only)
 
 NOTE ON "FOR ALL": whenever an item begins with "for all …", use the TodoWrite tool to create a separate task for each relevant endpoint/flow that needs to be analyzed.
-From `deliverables/pre_recon_deliverable.md`, use Section 3 and 6 to help guide your tasks.
+From `.shannon/deliverables/pre_recon_deliverable.md`, use Section 3 and 6 to help guide your tasks.
 
 ## 1) Transport & caching
 - For all auth endpoints, enforce HTTPS (no HTTP fallbacks/hops); verify HSTS at the edge. (for all: use TodoWrite tool to add each endpoint as a task)
@@ -244,10 +244,10 @@ These components were analyzed and found to have robust defenses. They are low-p
 1.  **Systematic Analysis:** ALL relevant API endpoints and user-facing features identified in the reconnaissance deliverable must be analyzed for AuthN/AuthZ flaws.
 2.  **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
     - **CHUNKED WRITING (MANDATORY):**
-      1. Use the **Write** tool to create `deliverables/auth_analysis_deliverable.md` with the title and first major section
+      1. Use the **Write** tool to create `.shannon/deliverables/auth_analysis_deliverable.md` with the title and first major section
       2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
       3. Repeat step 2 for all remaining sections
-      4. Run `save-deliverable` with `--type AUTH_ANALYSIS --file-path "deliverables/auth_analysis_deliverable.md"`
+      4. Run `save-deliverable` with `--type AUTH_ANALYSIS --file-path ".shannon/deliverables/auth_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
 **Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.

--- a/apps/worker/prompts/vuln-authz.txt
+++ b/apps/worker/prompts/vuln-authz.txt
@@ -32,7 +32,7 @@ Success criterion: A complete, code-backed analysis of every potential authoriza
 </critical>
 
 <starting_context>
-- Your **primary source of truth** for authorization test targets is the reconnaissance report at `deliverables/recon_deliverable.md`. Look specifically for:
+- Your **primary source of truth** for authorization test targets is the reconnaissance report at `.shannon/deliverables/recon_deliverable.md`. Look specifically for:
   - **"Horizontal" section:** Endpoints where users access resources by ID that might belong to other users
   - **"Vertical" section:** Admin/privileged endpoints that regular users shouldn't access
   - **"Context" section:** Multi-step workflows where order/state matters
@@ -44,8 +44,8 @@ Success criterion: A complete, code-backed analysis of every potential authoriza
 
 **Phase Sequence:** RECON (Complete) → **AUTHZ ANALYSIS (You)** → EXPLOITATION (next phase)
 
-**Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/authz_analysis_deliverable.md` (analysis report for exploitation phase)
+**Your Input:** `.shannon/deliverables/recon_deliverable.md`, `.shannon/deliverables/pre_recon_deliverable.md` (reconnaissance findings)
+**Your Output:** `.shannon/deliverables/authz_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, endpoints, and data flows
@@ -125,7 +125,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 ### 1) Horizontal Authorization Analysis
 
 - **Create To Dos:**
-    For each item listed under **`deliverables/recon_deliverable.md` → section 8 "Horizontal"*, use the TodoWrite tool to create a task entry.
+    For each item listed under **`.shannon/deliverables/recon_deliverable.md` → section 8 "Horizontal"*, use the TodoWrite tool to create a task entry.
     
 - **Process:**
     - Start at the identified endpoint.
@@ -157,7 +157,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 ### 2) Vertical Authorization Analysis
 
 - **Create To Dos:**
-    For each item listed under **`deliverables/recon_deliverable.md` →  section 8 "Vertical"**, use the TodoWrite tool to create a task entry.
+    For each item listed under **`.shannon/deliverables/recon_deliverable.md` →  section 8 "Vertical"**, use the TodoWrite tool to create a task entry.
     
 - **Process:**
     - Start at the identified endpoint.
@@ -183,7 +183,7 @@ An **exploitable vulnerability** is a logical flaw in the code that represents a
 ### 3) Context / Workflow Authorization Analysis
 
 - **Create To Dos:**
-    For each item listed under **`deliverables/recon_deliverable.md` → section 8 "Context"**, use the TodoWrite tool to create a task entry.
+    For each item listed under **`.shannon/deliverables/recon_deliverable.md` → section 8 "Context"**, use the TodoWrite tool to create a task entry.
     
 - **Process:**
     - Start at the endpoint that represents a step in a workflow.
@@ -347,10 +347,10 @@ examples:
 1. **Todo Completion:** ALL tasks in your TodoWrite list must be marked as "completed"
 2. **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
    - **CHUNKED WRITING (MANDATORY):**
-     1. Use the **Write** tool to create `deliverables/authz_analysis_deliverable.md` with the title and first major section
+     1. Use the **Write** tool to create `.shannon/deliverables/authz_analysis_deliverable.md` with the title and first major section
      2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
      3. Repeat step 2 for all remaining sections
-     4. Run `save-deliverable` with `--type AUTHZ_ANALYSIS --file-path "deliverables/authz_analysis_deliverable.md"`
+     4. Run `save-deliverable` with `--type AUTHZ_ANALYSIS --file-path ".shannon/deliverables/authz_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
 **Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.

--- a/apps/worker/prompts/vuln-injection.txt
+++ b/apps/worker/prompts/vuln-injection.txt
@@ -33,7 +33,7 @@ Success criterion: Complete source-to-sink traces detailing path, sanitizers, si
 </critical>
 
 <starting_context>
-- Your **single source of truth** for the application's structure is the reconnaissance report located at `deliverables/recon_deliverable.md`. You must derive your list of testable targets from this file.
+- Your **single source of truth** for the application's structure is the reconnaissance report located at `.shannon/deliverables/recon_deliverable.md`. You must derive your list of testable targets from this file.
 
 </starting_context>
 
@@ -42,8 +42,8 @@ Success criterion: Complete source-to-sink traces detailing path, sanitizers, si
 
 **Phase Sequence:** RECON (Complete) → **INJECTION ANALYSIS (You)** → EXPLOITATION (next phase)
 
-**Your Input:** `deliverables/recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/injection_analysis_deliverable.md` (analysis report for exploitation phase)
+**Your Input:** `.shannon/deliverables/recon_deliverable.md` (reconnaissance findings)
+**Your Output:** `.shannon/deliverables/injection_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, attack surfaces, endpoints, input vectors
@@ -124,7 +124,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 
   - **Goal:** Prove whether untrusted input can influence the **structure** of a backend command (SQL or Shell) or reach sensitive **slots** without the correct defense. No live exploitation in this phase.
   - **1) Create a To Do for each Injection Source found in the Pre-Recon Deliverable
-		  - inside of deliverables/pre_recon_deliverable.md under the section "7. Injection Sources (Command Injection and SQL Injection)" use the TodoWrite tool to create a task for each discovered Injection Source. 
+		  - inside of .shannon/deliverables/pre_recon_deliverable.md under the section "7. Injection Sources (Command Injection and SQL Injection)" use the TodoWrite tool to create a task for each discovered Injection Source. 
 		  - Note: All sources are marked as Tainted until they Hit a Santiization that matches the sink context. normalizers (lowercasing, trimming, JSON parse, schema decode) — still **tainted**.
     - **2) Trace Data Flow Paths from Source to Sink**
 		    - For each source, your goal is to identify every unique "Data Flow Path" to a database sink. A path is a distinct route the data takes through the code.
@@ -148,7 +148,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
     - If concat occurred **after** sanitization, treat that sanitization as **non-effective** for this path.
   - **6) Append to findings list (consistent fields)**
 	  -  **If the verdict is `vulnerable`:** Include the finding in your exploitation queue. Set `externally_exploitable` to `true` ONLY if exploitable via public internet without internal access. Ensure all fields in the `exploitation_queue_format`, including a minimal `witness_payload`, are populated.
-    - **If the verdict is `safe`:** DO NOT add the finding to the exploitation queue. These secure vectors must be documented later in the "Vectors Analyzed and Confirmed Secure" section of your final Markdown report (`deliverables/injection_analysis_deliverable.md`).
+    - **If the verdict is `safe`:** DO NOT add the finding to the exploitation queue. These secure vectors must be documented later in the "Vectors Analyzed and Confirmed Secure" section of your final Markdown report (`.shannon/deliverables/injection_analysis_deliverable.md`).
     - **If a single source is found to be vulnerable via multiple, distinct paths to different sinks, you must create a separate vulnerability entry in the exploitation queue for each unique vulnerable path.**
     - **QUEUE INCLUSION CRITERIA:** ONLY include vulnerabilities where `externally_exploitable = true`. Exclude any vulnerability requiring internal network access, VPN, or direct server access.
 
@@ -287,7 +287,7 @@ When you have systematically analyzed all input vectors, you MUST generate two f
 
 **1. Your Specialist Deliverable**
 
-First, synthesize all of your findings into a single, detailed Markdown report located at `deliverables/injection_analysis_deliverable.md`. This report is the official record of your work.
+First, synthesize all of your findings into a single, detailed Markdown report located at `.shannon/deliverables/injection_analysis_deliverable.md`. This report is the official record of your work.
 
 Your report MUST use the following structure precisely:
 
@@ -352,10 +352,10 @@ These input vectors were traced and confirmed to have robust, context-appropriat
 1. **Todo Completion:** ALL tasks in your TodoWrite list must be marked as "completed"
 2. **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
    - **CHUNKED WRITING (MANDATORY):**
-     1. Use the **Write** tool to create `deliverables/injection_analysis_deliverable.md` with the title and first major section
+     1. Use the **Write** tool to create `.shannon/deliverables/injection_analysis_deliverable.md` with the title and first major section
      2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
      3. Repeat step 2 for all remaining sections
-     4. Run `save-deliverable` with `--type INJECTION_ANALYSIS --file-path "deliverables/injection_analysis_deliverable.md"`
+     4. Run `save-deliverable` with `--type INJECTION_ANALYSIS --file-path ".shannon/deliverables/injection_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
 **Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.

--- a/apps/worker/prompts/vuln-ssrf.txt
+++ b/apps/worker/prompts/vuln-ssrf.txt
@@ -32,7 +32,7 @@ Success criterion: A complete source-to-sink trace for every identified SSRF vul
 </critical>
 
 <starting_context>
-- Your primary source of truth for the application's structure is the reconnaissance report located at `deliverables/recon_deliverable.md`. You must derive your list of testable endpoints from this file.
+- Your primary source of truth for the application's structure is the reconnaissance report located at `.shannon/deliverables/recon_deliverable.md`. You must derive your list of testable endpoints from this file.
 </starting_context>
 
 <system_architecture>
@@ -40,8 +40,8 @@ Success criterion: A complete source-to-sink trace for every identified SSRF vul
 
 **Phase Sequence:** RECON (Complete) → **SSRF ANALYSIS (You)** → EXPLOITATION (next phase)
 
-**Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/ssrf_analysis_deliverable.md` (analysis report for exploitation phase)
+**Your Input:** `.shannon/deliverables/recon_deliverable.md`, `.shannon/deliverables/pre_recon_deliverable.md` (reconnaissance findings)
+**Your Output:** `.shannon/deliverables/ssrf_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture, endpoints, and data flows
@@ -114,7 +114,7 @@ An **exploitable vulnerability** is a data flow where user-controlled input infl
 # White-Box Vulnerability Analysis Procedure: Server-Side Request Forgery (SSRF)
 
 NOTE ON "FOR ALL": whenever an item begins with "for all …", use the TodoWrite tool to create a separate task for each relevant endpoint/flow that needs to be analyzed.
-From `deliverables/pre_recon_deliverable.md`, use Section 10 (SSRF Sinks) to guide your tasks.
+From `.shannon/deliverables/pre_recon_deliverable.md`, use Section 10 (SSRF Sinks) to guide your tasks.
 
 ## 1) Identify HTTP Client Usage Patterns
 - For all endpoints that accept URL parameters, callback URLs, webhook URLs, or file paths, trace how these inputs are processed.
@@ -166,7 +166,7 @@ From `deliverables/pre_recon_deliverable.md`, use Section 10 (SSRF Sinks) to gui
 
 ### **1) Create a To-Do Item for Each SSRF Sink**
 
-Inside `deliverables/pre_recon_deliverable.md` under section `##10. SSRF Sinks##`.
+Inside `.shannon/deliverables/pre_recon_deliverable.md` under section `##10. SSRF Sinks##`.
 
 Use the TodoWrite tool to create a task for each discovered sink (any server-side request composed even partially from user input).
 
@@ -291,10 +291,10 @@ These components were analyzed and found to have robust defenses. They are low-p
 1.  **Systematic Analysis:** ALL relevant API endpoints and request-making features identified in the reconnaissance deliverable must be analyzed for SSRF vulnerabilities.
 2.  **Deliverable Generation:** Your deliverable must be successfully saved using the save-deliverable CLI tool:
     - **CHUNKED WRITING (MANDATORY):**
-      1. Use the **Write** tool to create `deliverables/ssrf_analysis_deliverable.md` with the title and first major section
+      1. Use the **Write** tool to create `.shannon/deliverables/ssrf_analysis_deliverable.md` with the title and first major section
       2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
       3. Repeat step 2 for all remaining sections
-      4. Run `save-deliverable` with `--type SSRF_ANALYSIS --file-path "deliverables/ssrf_analysis_deliverable.md"`
+      4. Run `save-deliverable` with `--type SSRF_ANALYSIS --file-path ".shannon/deliverables/ssrf_analysis_deliverable.md"`
       **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
 **Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.

--- a/apps/worker/prompts/vuln-xss.txt
+++ b/apps/worker/prompts/vuln-xss.txt
@@ -32,7 +32,7 @@ Success criterion: Live confirmation of XSS execution for every vulnerability th
 </critical>
 
 <starting_context>
-- Your primary source of truth for the application's structure is the reconnaissance report located at deliverables/recon_deliverable.md. You must derive your list of testable targets from this file.
+- Your primary source of truth for the application's structure is the reconnaissance report located at .shannon/deliverables/recon_deliverable.md. You must derive your list of testable targets from this file.
 </starting_context>
 
 <system_architecture>
@@ -40,8 +40,8 @@ Success criterion: Live confirmation of XSS execution for every vulnerability th
 
 **Phase Sequence:** RECON (Complete) → **XSS ANALYSIS (You)** → EXPLOITATION (next phase)
 
-**Your Input:** `deliverables/recon_deliverable.md`, `deliverables/pre_recon_deliverable.md` (reconnaissance findings)
-**Your Output:** `deliverables/xss_analysis_deliverable.md` (analysis report for exploitation phase)
+**Your Input:** `.shannon/deliverables/recon_deliverable.md`, `.shannon/deliverables/pre_recon_deliverable.md` (reconnaissance findings)
+**Your Output:** `.shannon/deliverables/xss_analysis_deliverable.md` (analysis report for exploitation phase)
 
 **WHAT HAPPENED BEFORE YOU:**
 - Reconnaissance agent mapped application architecture
@@ -72,7 +72,7 @@ An **exploitable vulnerability** is a confirmed source-to-sink path where the en
 
 **CRITICAL TOOL USAGE RESTRICTIONS:**
 - NEVER use the Read tool for application source code analysis - ALWAYS delegate to Task agents for examining .js, .ts, .py, .php files and application logic. You MAY use Read
-  tool directly for these files: `deliverables/pre_recon_deliverable.md`, `deliverables/recon_deliverable.md`
+  tool directly for these files: `.shannon/deliverables/pre_recon_deliverable.md`, `.shannon/deliverables/recon_deliverable.md`
 - Direct the Task Agent to trace render contexts, sanitization coverage, and template/component boundaries before deciding on exploitability.
 - **ALWAYS delegate code analysis to Task agents**
 
@@ -124,7 +124,7 @@ Structure: The vulnerability JSON object MUST follow this exact format:
 - **Core Principle:** Data is assumed to be tainted until a context-appropriate output encoder (sanitization) is encountered on its path to the sink.
 
 ### **1) Create a todo item for each XSS sink using the TodoWrite tool**
-Read deliverables/pre_recon_deliverable.md section ##9. XSS Sinks and Render Contexts## and use the **TodoWrite tool** to create a todo item for each discovered sink-context pair that needs analysis.
+Read .shannon/deliverables/pre_recon_deliverable.md section ##9. XSS Sinks and Render Contexts## and use the **TodoWrite tool** to create a todo item for each discovered sink-context pair that needs analysis.
 
 ### **2) Trace Each Sink Backward (Backward Taint Analysis)**
 For each pending item in your todo list (managed via TodoWrite tool), trace the origin of the data variable backward from the sink through the application logic. Your goal is to find either a valid sanitizer or an untrusted source. Mark each todo item as completed after you've fully analyzed that sink.
@@ -211,7 +211,7 @@ When you have systematically analyzed all input vectors, you MUST generate two f
 ## 1. Your Specialist Deliverable
 
 - First, synthesize all of your findings into a single, detailed Markdown report located at  
-  `deliverables/xss_analysis_deliverable.md`.
+  `.shannon/deliverables/xss_analysis_deliverable.md`.
 
 - Your report MUST use the following structure precisely:
 
@@ -272,10 +272,10 @@ COMPLETION REQUIREMENTS (ALL must be satisfied):
 1. Systematic Analysis: ALL input vectors identified from the reconnaissance deliverable must be analyzed.
 2. Deliverable Generation: Your deliverable must be successfully saved using the save-deliverable CLI tool:
    - **CHUNKED WRITING (MANDATORY):**
-     1. Use the **Write** tool to create `deliverables/xss_analysis_deliverable.md` with the title and first major section
+     1. Use the **Write** tool to create `.shannon/deliverables/xss_analysis_deliverable.md` with the title and first major section
      2. Use the **Edit** tool to append each remaining section — match the last few lines of the file, then replace with those lines plus the new section content
      3. Repeat step 2 for all remaining sections
-     4. Run `save-deliverable` with `--type XSS_ANALYSIS --file-path "deliverables/xss_analysis_deliverable.md"`
+     4. Run `save-deliverable` with `--type XSS_ANALYSIS --file-path ".shannon/deliverables/xss_analysis_deliverable.md"`
      **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations.
 
 **Note:** Save your deliverable markdown via save-deliverable first. The exploitation queue is captured automatically at the end of your session.

--- a/apps/worker/src/ai/claude-executor.ts
+++ b/apps/worker/src/ai/claude-executor.ts
@@ -72,7 +72,7 @@ async function writeErrorLog(
       },
       duration,
     };
-    const logPath = path.join(sourceDir, 'deliverables', 'error.log');
+    const logPath = path.join(sourceDir, '.shannon', 'deliverables', 'error.log');
     await fs.appendFile(logPath, `${JSON.stringify(errorLog)}\n`);
   } catch {
     // Best-effort error log writing - don't propagate failures

--- a/apps/worker/src/ai/claude-executor.ts
+++ b/apps/worker/src/ai/claude-executor.ts
@@ -152,6 +152,7 @@ export async function runClaudePrompt(
   // 3. Build env vars to pass to SDK subprocesses
   const sdkEnv: Record<string, string> = {
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS || '64000',
+    PLAYWRIGHT_MCP_OUTPUT_DIR: path.join(sourceDir, '.shannon', '.playwright-cli'),
   };
   const passthroughVars = [
     'ANTHROPIC_API_KEY',

--- a/apps/worker/src/ai/claude-executor.ts
+++ b/apps/worker/src/ai/claude-executor.ts
@@ -72,7 +72,7 @@ async function writeErrorLog(
       },
       duration,
     };
-    const logPath = path.join(sourceDir, 'error.log');
+    const logPath = path.join(sourceDir, 'deliverables', 'error.log');
     await fs.appendFile(logPath, `${JSON.stringify(errorLog)}\n`);
   } catch {
     // Best-effort error log writing - don't propagate failures

--- a/apps/worker/src/audit/utils.ts
+++ b/apps/worker/src/audit/utils.ts
@@ -11,7 +11,6 @@
  * All functions are pure and crash-safe.
  */
 
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import { WORKSPACES_DIR } from '../paths.js';
 import { ensureDirectory } from '../utils/file-io.js';
@@ -97,34 +96,4 @@ export async function initializeAuditStructure(sessionMetadata: SessionMetadata)
   await ensureDirectory(agentsPath);
   await ensureDirectory(promptsPath);
   await ensureDirectory(deliverablesPath);
-}
-
-/**
- * Copy deliverable files from repo to workspaces for self-contained audit trail.
- * No-ops if source directory doesn't exist. Idempotent and parallel-safe.
- */
-export async function copyDeliverablesToAudit(sessionMetadata: SessionMetadata, repoPath: string): Promise<void> {
-  const sourceDir = path.join(repoPath, 'deliverables');
-  const destDir = path.join(generateAuditPath(sessionMetadata), 'deliverables');
-
-  let entries: string[];
-  try {
-    entries = await fs.readdir(sourceDir);
-  } catch {
-    // Source directory doesn't exist yet — nothing to copy
-    return;
-  }
-
-  await ensureDirectory(destDir);
-
-  for (const entry of entries) {
-    const sourcePath = path.join(sourceDir, entry);
-    const destPath = path.join(destDir, entry);
-
-    // Only copy files, skip subdirectories
-    const stat = await fs.stat(sourcePath);
-    if (stat.isFile()) {
-      await fs.copyFile(sourcePath, destPath);
-    }
-  }
 }

--- a/apps/worker/src/scripts/save-deliverable.ts
+++ b/apps/worker/src/scripts/save-deliverable.ts
@@ -52,7 +52,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 // === File Operations ===
 
 function saveDeliverableFile(targetDir: string, filename: string, content: string): string {
-  const deliverablesDir = join(targetDir, 'deliverables');
+  const deliverablesDir = join(targetDir, '.shannon', 'deliverables');
   const filepath = join(deliverablesDir, filename);
 
   try {

--- a/apps/worker/src/services/agent-execution.ts
+++ b/apps/worker/src/services/agent-execution.ts
@@ -184,7 +184,7 @@ export class AgentExecutionService {
     // 8. Write structured output to disk (vuln agents only)
     const queueFilename = getQueueFilename(agentName);
     if (result.structuredOutput !== undefined && queueFilename) {
-      const deliverablesDir = path.join(repoPath, 'deliverables');
+      const deliverablesDir = path.join(repoPath, '.shannon', 'deliverables');
       await fs.ensureDir(deliverablesDir);
       const queuePath = path.join(deliverablesDir, queueFilename);
       await fs.writeFile(queuePath, JSON.stringify(result.structuredOutput, null, 2), 'utf8');

--- a/apps/worker/src/services/agent-execution.ts
+++ b/apps/worker/src/services/agent-execution.ts
@@ -44,6 +44,7 @@ import { loadPrompt } from './prompt-manager.js';
 export interface AgentExecutionInput {
   webUrl: string;
   repoPath: string;
+  deliverablesPath: string;
   configPath?: string | undefined;
   pipelineTestingMode?: boolean | undefined;
   attemptNumber: number;
@@ -89,7 +90,7 @@ export class AgentExecutionService {
     auditSession: AuditSession,
     logger: ActivityLogger,
   ): Promise<Result<AgentEndResult, PentestError>> {
-    const { webUrl, repoPath, configPath, pipelineTestingMode = false, attemptNumber } = input;
+    const { webUrl, repoPath, deliverablesPath, configPath, pipelineTestingMode = false, attemptNumber } = input;
 
     // 1. Load config (if provided)
     const configResult = await this.configLoader.loadOptional(configPath);
@@ -118,7 +119,7 @@ export class AgentExecutionService {
 
     // 3. Create git checkpoint before execution
     try {
-      await createGitCheckpoint(repoPath, agentName, attemptNumber, logger);
+      await createGitCheckpoint(deliverablesPath, agentName, attemptNumber, logger);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       return err(
@@ -126,7 +127,7 @@ export class AgentExecutionService {
           `Failed to create git checkpoint for ${agentName}: ${errorMessage}`,
           'filesystem',
           false,
-          { agentName, repoPath, originalError: errorMessage },
+          { agentName, deliverablesPath, originalError: errorMessage },
           ErrorCode.GIT_CHECKPOINT_FAILED,
         ),
       );
@@ -153,7 +154,7 @@ export class AgentExecutionService {
     if (result.success && (result.turns ?? 0) <= 2 && (result.cost || 0) === 0) {
       const resultText = result.result || '';
       if (isSpendingCapBehavior(result.turns ?? 0, result.cost || 0, resultText)) {
-        return this.failAgent(agentName, repoPath, auditSession, logger, {
+        return this.failAgent(agentName, deliverablesPath, auditSession, logger, {
           attemptNumber,
           result,
           rollbackReason: 'spending cap detected',
@@ -168,7 +169,7 @@ export class AgentExecutionService {
 
     // 7. Handle execution failure
     if (!result.success) {
-      return this.failAgent(agentName, repoPath, auditSession, logger, {
+      return this.failAgent(agentName, deliverablesPath, auditSession, logger, {
         attemptNumber,
         result,
         rollbackReason: 'execution failure',
@@ -193,7 +194,7 @@ export class AgentExecutionService {
     // 9. Validate output
     const validationPassed = await validateAgentOutput(result, agentName, repoPath, logger);
     if (!validationPassed) {
-      return this.failAgent(agentName, repoPath, auditSession, logger, {
+      return this.failAgent(agentName, deliverablesPath, auditSession, logger, {
         attemptNumber,
         result,
         rollbackReason: 'validation failure',
@@ -206,8 +207,8 @@ export class AgentExecutionService {
     }
 
     // 10. Success - commit deliverables, then capture checkpoint hash
-    await commitGitSuccess(repoPath, agentName, logger);
-    const commitHash = await getGitCommitHash(repoPath);
+    await commitGitSuccess(deliverablesPath, agentName, logger);
+    const commitHash = await getGitCommitHash(deliverablesPath);
 
     const endResult: AgentEndResult = {
       attemptNumber,
@@ -224,12 +225,12 @@ export class AgentExecutionService {
 
   private async failAgent(
     agentName: AgentName,
-    repoPath: string,
+    deliverablesPath: string,
     auditSession: AuditSession,
     logger: ActivityLogger,
     opts: FailAgentOpts,
   ): Promise<Result<AgentEndResult, PentestError>> {
-    await rollbackGitWorkspace(repoPath, opts.rollbackReason, logger);
+    await rollbackGitWorkspace(deliverablesPath, opts.rollbackReason, logger);
 
     const endResult: AgentEndResult = {
       attemptNumber: opts.attemptNumber,

--- a/apps/worker/src/services/queue-validation.ts
+++ b/apps/worker/src/services/queue-validation.ts
@@ -133,8 +133,8 @@ const createPaths = (vulnType: VulnType, sourceDir: string): PathsBase | PathsWi
 
   return Object.freeze({
     vulnType,
-    deliverable: path.join(sourceDir, 'deliverables', config.deliverable),
-    queue: path.join(sourceDir, 'deliverables', config.queue),
+    deliverable: path.join(sourceDir, '.shannon', 'deliverables', config.deliverable),
+    queue: path.join(sourceDir, '.shannon', 'deliverables', config.queue),
     sourceDir,
   });
 };

--- a/apps/worker/src/services/reporting.ts
+++ b/apps/worker/src/services/reporting.ts
@@ -28,7 +28,7 @@ export async function assembleFinalReport(sourceDir: string, logger: ActivityLog
   const sections: string[] = [];
 
   for (const file of deliverableFiles) {
-    const filePath = path.join(sourceDir, 'deliverables', file.path);
+    const filePath = path.join(sourceDir, '.shannon', 'deliverables', file.path);
     try {
       if (await fs.pathExists(filePath)) {
         const content = await fs.readFile(filePath, 'utf8');
@@ -55,7 +55,7 @@ export async function assembleFinalReport(sourceDir: string, logger: ActivityLog
   }
 
   const finalContent = sections.join('\n\n');
-  const deliverablesDir = path.join(sourceDir, 'deliverables');
+  const deliverablesDir = path.join(sourceDir, '.shannon', 'deliverables');
   const finalReportPath = path.join(deliverablesDir, 'comprehensive_security_assessment_report.md');
 
   try {
@@ -117,7 +117,7 @@ export async function injectModelIntoReport(
   logger.info(`Injecting model info into report: ${modelStr}`);
 
   // 3. Read the final report
-  const reportPath = path.join(repoPath, 'deliverables', 'comprehensive_security_assessment_report.md');
+  const reportPath = path.join(repoPath, '.shannon', 'deliverables', 'comprehensive_security_assessment_report.md');
 
   if (!(await fs.pathExists(reportPath))) {
     logger.warn('Final report not found, skipping model injection');

--- a/apps/worker/src/session-manager.ts
+++ b/apps/worker/src/session-manager.ts
@@ -143,7 +143,7 @@ function createVulnValidator(vulnType: VulnType): AgentValidator {
 // Factory function for exploit deliverable validators
 function createExploitValidator(vulnType: VulnType): AgentValidator {
   return async (sourceDir: string): Promise<boolean> => {
-    const evidenceFile = path.join(sourceDir, 'deliverables', `${vulnType}_exploitation_evidence.md`);
+    const evidenceFile = path.join(sourceDir, '.shannon', 'deliverables', `${vulnType}_exploitation_evidence.md`);
     return await fs.pathExists(evidenceFile);
   };
 }
@@ -179,13 +179,13 @@ export const PLAYWRIGHT_SESSION_MAPPING: Record<string, PlaywrightSession> = Obj
 export const AGENT_VALIDATORS: Record<AgentName, AgentValidator> = Object.freeze({
   // Pre-reconnaissance agent - validates the code analysis deliverable created by the agent
   'pre-recon': async (sourceDir: string): Promise<boolean> => {
-    const codeAnalysisFile = path.join(sourceDir, 'deliverables', 'code_analysis_deliverable.md');
+    const codeAnalysisFile = path.join(sourceDir, '.shannon', 'deliverables', 'code_analysis_deliverable.md');
     return await fs.pathExists(codeAnalysisFile);
   },
 
   // Reconnaissance agent
   recon: async (sourceDir: string): Promise<boolean> => {
-    const reconFile = path.join(sourceDir, 'deliverables', 'recon_deliverable.md');
+    const reconFile = path.join(sourceDir, '.shannon', 'deliverables', 'recon_deliverable.md');
     return await fs.pathExists(reconFile);
   },
 
@@ -205,7 +205,7 @@ export const AGENT_VALIDATORS: Record<AgentName, AgentValidator> = Object.freeze
 
   // Executive report agent
   report: async (sourceDir: string, logger: ActivityLogger): Promise<boolean> => {
-    const reportFile = path.join(sourceDir, 'deliverables', 'comprehensive_security_assessment_report.md');
+    const reportFile = path.join(sourceDir, '.shannon', 'deliverables', 'comprehensive_security_assessment_report.md');
 
     const reportExists = await fs.pathExists(reportFile);
 

--- a/apps/worker/src/temporal/activities.ts
+++ b/apps/worker/src/temporal/activities.ts
@@ -126,7 +126,7 @@ async function runAgentActivity(agentName: AgentName, input: ActivityInput): Pro
     await auditSession.initialize(workflowId);
 
     // 3. Execute agent via service (throws PentestError on failure)
-    const deliverablesPath = path.join(repoPath, 'deliverables');
+    const deliverablesPath = path.join(repoPath, '.shannon', 'deliverables');
     const endResult = await container.agentExecution.executeOrThrow(
       agentName,
       {
@@ -318,7 +318,7 @@ export async function runPreflightValidation(input: ActivityInput): Promise<void
  * Idempotent — skips if .git already exists (resume case).
  */
 export async function initDeliverableGit(input: ActivityInput): Promise<void> {
-  const deliverablesPath = path.join(input.repoPath, 'deliverables');
+  const deliverablesPath = path.join(input.repoPath, '.shannon', 'deliverables');
   await fs.mkdir(deliverablesPath, { recursive: true });
 
   // Check for .git directly inside deliverables, not parent repo's .git
@@ -453,7 +453,7 @@ export async function loadResumeState(
     }
 
     const deliverableFilename = AGENTS[agentName].deliverableFilename;
-    const deliverablePath = `${expectedRepoPath}/deliverables/${deliverableFilename}`;
+    const deliverablePath = `${expectedRepoPath}/.shannon/deliverables/${deliverableFilename}`;
     const deliverableExists = await fileExists(deliverablePath);
 
     if (!deliverableExists) {
@@ -487,7 +487,7 @@ export async function loadResumeState(
   }
 
   // 5. Find the most recent checkpoint commit
-  const deliverablesPath = path.join(expectedRepoPath, 'deliverables');
+  const deliverablesPath = path.join(expectedRepoPath, '.shannon', 'deliverables');
   const checkpointHash = await findLatestCommit(deliverablesPath, checkpoints);
   const originalWorkflowId = session.session.originalWorkflowId || session.session.id;
 
@@ -541,7 +541,7 @@ export async function restoreGitCheckpoint(
   checkpointHash: string,
   incompleteAgents: AgentName[],
 ): Promise<void> {
-  const deliverablesPath = path.join(repoPath, 'deliverables');
+  const deliverablesPath = path.join(repoPath, '.shannon', 'deliverables');
   const logger = createActivityLogger();
   logger.info(`Restoring deliverables to ${checkpointHash}...`);
 

--- a/apps/worker/src/temporal/activities.ts
+++ b/apps/worker/src/temporal/activities.ts
@@ -20,7 +20,7 @@ import path from 'node:path';
 import { ApplicationFailure, Context, heartbeat } from '@temporalio/activity';
 import { AuditSession } from '../audit/index.js';
 import type { ResumeAttempt } from '../audit/metrics-tracker.js';
-import { copyDeliverablesToAudit, type SessionMetadata } from '../audit/utils.js';
+import type { SessionMetadata } from '../audit/utils.js';
 import type { WorkflowSummary } from '../audit/workflow-logger.js';
 import { getContainer, getOrCreateContainer, removeContainer } from '../services/container.js';
 import { classifyErrorForTemporal, PentestError } from '../services/error-handling.js';
@@ -126,11 +126,13 @@ async function runAgentActivity(agentName: AgentName, input: ActivityInput): Pro
     await auditSession.initialize(workflowId);
 
     // 3. Execute agent via service (throws PentestError on failure)
+    const deliverablesPath = path.join(repoPath, 'deliverables');
     const endResult = await container.agentExecution.executeOrThrow(
       agentName,
       {
         webUrl,
         repoPath,
+        deliverablesPath,
         configPath,
         pipelineTestingMode,
         attemptNumber,
@@ -312,6 +314,31 @@ export async function runPreflightValidation(input: ActivityInput): Promise<void
 }
 
 /**
+ * Initialize a private git repository inside the workspace deliverables directory.
+ * Idempotent — skips if .git already exists (resume case).
+ */
+export async function initDeliverableGit(input: ActivityInput): Promise<void> {
+  const deliverablesPath = path.join(input.repoPath, 'deliverables');
+  await fs.mkdir(deliverablesPath, { recursive: true });
+
+  // Check for .git directly inside deliverables, not parent repo's .git
+  const dotGitPath = path.join(deliverablesPath, '.git');
+  try {
+    await fs.stat(dotGitPath);
+    return;
+  } catch {
+    // .git doesn't exist, proceed with init
+  }
+
+  await executeGitCommandWithRetry(['git', 'init'], deliverablesPath, 'init deliverables repo');
+  await executeGitCommandWithRetry(
+    ['git', 'commit', '--allow-empty', '-m', '📍 Initial deliverables checkpoint'],
+    deliverablesPath,
+    'initial checkpoint',
+  );
+}
+
+/**
  * Assemble the final report by concatenating exploitation evidence files.
  */
 export async function assembleReportActivity(input: ActivityInput): Promise<void> {
@@ -460,7 +487,8 @@ export async function loadResumeState(
   }
 
   // 5. Find the most recent checkpoint commit
-  const checkpointHash = await findLatestCommit(expectedRepoPath, checkpoints);
+  const deliverablesPath = path.join(expectedRepoPath, 'deliverables');
+  const checkpointHash = await findLatestCommit(deliverablesPath, checkpoints);
   const originalWorkflowId = session.session.originalWorkflowId || session.session.id;
 
   // 6. Log summary and return resume state
@@ -480,7 +508,7 @@ export async function loadResumeState(
   };
 }
 
-async function findLatestCommit(repoPath: string, commitHashes: string[]): Promise<string> {
+async function findLatestCommit(gitDir: string, commitHashes: string[]): Promise<string> {
   if (commitHashes.length === 1) {
     const hash = commitHashes[0];
     if (!hash) {
@@ -497,7 +525,7 @@ async function findLatestCommit(repoPath: string, commitHashes: string[]): Promi
 
   const result = await executeGitCommandWithRetry(
     ['git', 'rev-list', '--max-count=1', ...commitHashes],
-    repoPath,
+    gitDir,
     'find latest commit',
   );
 
@@ -505,26 +533,29 @@ async function findLatestCommit(repoPath: string, commitHashes: string[]): Promi
 }
 
 /**
- * Restore git workspace to a checkpoint and clean up partial deliverables.
+ * Restore deliverables git to a checkpoint.
+ * Operates on the private git inside workspace deliverables, not the user's repo.
  */
 export async function restoreGitCheckpoint(
   repoPath: string,
   checkpointHash: string,
   incompleteAgents: AgentName[],
 ): Promise<void> {
+  const deliverablesPath = path.join(repoPath, 'deliverables');
   const logger = createActivityLogger();
-  logger.info(`Restoring git workspace to ${checkpointHash}...`);
+  logger.info(`Restoring deliverables to ${checkpointHash}...`);
 
   await executeGitCommandWithRetry(
     ['git', 'reset', '--hard', checkpointHash],
-    repoPath,
-    'reset to checkpoint for resume',
+    deliverablesPath,
+    'reset deliverables to checkpoint',
   );
-  await executeGitCommandWithRetry(['git', 'clean', '-fd'], repoPath, 'clean untracked files for resume');
+  await executeGitCommandWithRetry(['git', 'clean', '-fd'], deliverablesPath, 'clean untracked deliverables');
 
+  // Explicitly delete partial deliverables for incomplete agents
   for (const agentName of incompleteAgents) {
     const deliverableFilename = AGENTS[agentName].deliverableFilename;
-    const deliverablePath = `${repoPath}/deliverables/${deliverableFilename}`;
+    const deliverablePath = path.join(deliverablesPath, deliverableFilename);
     try {
       const exists = await fileExists(deliverablePath);
       if (exists) {
@@ -536,7 +567,7 @@ export async function restoreGitCheckpoint(
     }
   }
 
-  logger.info('Workspace restored to clean state');
+  logger.info('Deliverables restored to clean state');
 }
 
 /**
@@ -589,7 +620,7 @@ export async function logPhaseTransition(
  * Cleans up container when done.
  */
 export async function logWorkflowComplete(input: ActivityInput, summary: WorkflowSummary): Promise<void> {
-  const { repoPath, workflowId } = input;
+  const { workflowId } = input;
   const sessionMetadata = buildSessionMetadata(input);
 
   // 1. Initialize audit session and mark final status
@@ -631,16 +662,6 @@ export async function logWorkflowComplete(input: ActivityInput, summary: Workflo
   // 5. Write completion entry to workflow.log
   await auditSession.logWorkflowComplete(cumulativeSummary);
 
-  // 6. Copy deliverables to workspaces
-  try {
-    await copyDeliverablesToAudit(sessionMetadata, repoPath);
-  } catch (copyErr) {
-    const logger = createActivityLogger();
-    logger.error('Failed to copy deliverables to workspaces', {
-      error: copyErr instanceof Error ? copyErr.message : String(copyErr),
-    });
-  }
-
-  // 7. Clean up container
+  // 6. Clean up container
   removeContainer(workflowId);
 }

--- a/apps/worker/src/temporal/worker.ts
+++ b/apps/worker/src/temporal/worker.ts
@@ -375,6 +375,7 @@ function copyDeliverables(repoPath: string, outputPath: string): void {
   fs.mkdirSync(outputPath, { recursive: true });
 
   for (const file of files) {
+    if (file === '.git') continue;
     const src = path.join(deliverablesDir, file);
     const dest = path.join(outputPath, file);
     fs.cpSync(src, dest, { recursive: true });

--- a/apps/worker/src/temporal/worker.ts
+++ b/apps/worker/src/temporal/worker.ts
@@ -360,7 +360,7 @@ async function waitForWorkflowResult(
 // === Deliverables Copy ===
 
 function copyDeliverables(repoPath: string, outputPath: string): void {
-  const deliverablesDir = path.join(repoPath, 'deliverables');
+  const deliverablesDir = path.join(repoPath, '.shannon', 'deliverables');
   if (!fs.existsSync(deliverablesDir)) {
     console.log('No deliverables directory found, skipping copy');
     return;

--- a/apps/worker/src/temporal/workflows.ts
+++ b/apps/worker/src/temporal/workflows.ts
@@ -362,6 +362,9 @@ export async function pentestPipelineWorkflow(input: PipelineInput): Promise<Pip
     await preflightActs.runPreflightValidation(activityInput);
     log.info('Preflight validation passed');
 
+    // === Initialize Deliverables Git ===
+    await a.initDeliverableGit(activityInput);
+
     // === Phase 1: Pre-Reconnaissance ===
     await runSequentialPhase('pre-recon', 'pre-recon', a.runPreReconAgent);
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [ -n "$TARGET_UID" ] && [ "$TARGET_UID" != "$CURRENT_UID" ]; then
   addgroup -g "$TARGET_GID" pentest
   adduser -u "$TARGET_UID" -G pentest -s /bin/bash -D pentest
 
-  chown -R pentest:pentest /app/sessions /app/deliverables /app/workspaces /tmp/.claude
+  chown -R pentest:pentest /app/sessions /app/workspaces /tmp/.claude
 fi
 
 exec su -m pentest -c "exec $*"


### PR DESCRIPTION
## Summary

- Mount the target repository as read-only (`:ro`) inside the Docker container, preventing agents from accidentally modifying user source code
- Namespace all writable paths under `deliverables/`, `scratchpad/`, `.playwright-cli/` backed by workspace-directory bind-mount overlays
- Initialize a private git repo inside deliverables so checkpoint/rollback operates on deliverables only, not the user's repo
- Update all prompts with explicit filesystem context showing which paths are read-only vs read-write
- Remove `copyDeliverablesToAudit` — deliverables now live directly in the workspace directory, eliminating the copy step