### PR TITLE
fix: update outdated OpenAI model names in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ ANTHROPIC_API_KEY=your-api-key-here
 
 # --- OpenAI ---
 # OPENAI_API_KEY=sk-your-openai-key
-# ROUTER_DEFAULT=openai,gpt-5.2
+# ROUTER_DEFAULT=openai,gpt-5.4
 
 # --- OpenRouter (access Gemini 3 models via single API) ---
 # OPENROUTER_API_KEY=sk-or-your-openrouter-key
@@ -76,5 +76,5 @@ ANTHROPIC_API_KEY=your-api-key-here
 # =============================================================================
 # Available Models
 # =============================================================================
-# OpenAI:     gpt-5.2, gpt-5-mini
+# OpenAI:     gpt-5.4, gpt-5.4-mini
 # OpenRouter: google/gemini-3-flash-preview


### PR DESCRIPTION
## What
Updated outdated OpenAI model names in `.env.example`.

## Why
- `gpt-5.2` is now OpenAI's previous model. The current recommended flagship is `gpt-5.4`.
- `gpt-5-mini` is outdated. OpenAI now recommends `gpt-5.4-mini` for high-volume workloads.

## References
- https://developers.openai.com/api/docs/models
- https://openai.com/index/introducing-gpt-5-4-mini-and-nano/