### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ ANTHROPIC_API_KEY=your-api-key-here
 # OPENROUTER_API_KEY=sk-or-your-openrouter-key
 # ROUTER_DEFAULT=openrouter,google/gemini-3-flash-preview
 
+# --- MiniMax ---
+# MINIMAX_API_KEY=your-minimax-api-key
+# ROUTER_DEFAULT=minimax,MiniMax-M2.7
+
 # =============================================================================
 # Model Tier Overrides (Anthropic API / OAuth / Custom Base URL / Bedrock)
 # =============================================================================
@@ -78,3 +82,4 @@ ANTHROPIC_API_KEY=your-api-key-here
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini
 # OpenRouter: google/gemini-3-flash-preview
+# MiniMax:    MiniMax-M2.7, MiniMax-M2.7-highspeed

--- a/apps/cli/infra/compose.yml
+++ b/apps/cli/infra/compose.yml
@@ -38,6 +38,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-openai,gpt-4o}
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3456/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]

--- a/apps/cli/infra/router-config.json
+++ b/apps/cli/infra/router-config.json
@@ -9,7 +9,7 @@
     {
       "name": "openai",
       "api_base_url": "https://api.openai.com/v1/chat/completions",
-      "api_key": "$OPENAI_API_KEY",
+      "api_key": "\$OPENAI_API_KEY",
       "models": ["gpt-5.2", "gpt-5-mini"],
       "transformer": {
         "use": [["maxcompletiontokens", { "max_completion_tokens": 16384 }]]
@@ -18,14 +18,20 @@
     {
       "name": "openrouter",
       "api_base_url": "https://openrouter.ai/api/v1/chat/completions",
-      "api_key": "$OPENROUTER_API_KEY",
+      "api_key": "\$OPENROUTER_API_KEY",
       "models": ["google/gemini-3-flash-preview"],
       "transformer": {
         "use": ["openrouter"]
       }
+    },
+    {
+      "name": "minimax",
+      "api_base_url": "https://api.minimax.io/v1/chat/completions",
+      "api_key": "\$MINIMAX_API_KEY",
+      "models": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
     }
   ],
   "Router": {
-    "default": "$ROUTER_DEFAULT"
+    "default": "\$ROUTER_DEFAULT"
   }
 }


### PR DESCRIPTION
## Summary

Adds MiniMax as a provider option in Shannon's router mode, enabling users to use MiniMax models as an alternative to Anthropic Claude.

### Changes

- **`apps/cli/infra/router-config.json`**: Add `minimax` provider entry with OpenAI-compatible API endpoint (`https://api.minimax.io/v1/chat/completions`) and models `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`
- **`apps/cli/infra/compose.yml`**: Pass `MINIMAX_API_KEY` environment variable to the router container
- **`.env.example`**: Document MiniMax configuration option and available models

### Usage

To use MiniMax with Shannon router mode:

```bash
# In your .env file:
MINIMAX_API_KEY=your-minimax-api-key
ROUTER_DEFAULT=minimax,MiniMax-M2.7

# Start with router mode:
./shannon start ... ROUTER=true
```

### MiniMax Models

| Model | Description |
|-------|-------------|
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

API reference:
- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api