### PR TITLE
Fix local run blockers for build/check/clean and Windows launcher

### DIFF
--- a/PR_DRAFT_RUN_BLOCKER_FIXES.md
+++ b/PR_DRAFT_RUN_BLOCKER_FIXES.md
@@ -1,0 +1,95 @@
+# Draft PR: Fix local run blockers for build/check/clean and Windows launcher
+
+## What changed
+
+This patch fixes a set of reproducible local run blockers in the Shannon monorepo.
+
+Changes included:
+- replace root `turbo`-based `build`, `check`, and `clean` wrappers with a direct workspace task runner
+- replace Unix-only `rm -rf dist` cleanup scripts with cross-platform Node-based cleanup
+- fix the local `shannon` launcher to await the CLI import
+- add `shannon.cmd` for Windows PowerShell / Command Prompt local usage
+- update clone/build docs in `README.md` to reflect the working local flow
+- add `RUN_BLOCKER_FIXES.md` to document the issue, root cause, patch, and validation
+
+## Why this changed
+
+These issues were reproducible in a Windows PowerShell environment and blocked normal local use of the repository.
+
+### Issue 1: root workspace commands failed
+
+Observed failure:
+- `corepack pnpm build`
+- `corepack pnpm check`
+
+Failure message:
+- `turbo`: `Unable to find package manager binary: cannot find binary path`
+
+Impact:
+- monorepo build/check failed before package code ran
+
+Patch:
+- remove the dependency on root `turbo run ...` for the documented local build/check/clean path
+- run workspace tasks directly from a repo-local script
+
+### Issue 2: local launcher was unreliable
+
+Observed behavior:
+- `.\shannon help` did not behave reliably as a local entrypoint
+
+Impact:
+- local clone usage was fragile, especially on Windows
+
+Patch:
+- make the repo launcher explicitly await the dynamic CLI import
+- add a Windows wrapper script: `shannon.cmd`
+
+### Issue 3: clean scripts were Unix-only
+
+Observed behavior:
+- package `clean` scripts used `rm -rf dist`
+
+Impact:
+- clean failed on standard Windows shells
+
+Patch:
+- replace shell-specific cleanup with `fs.rmSync(..., { recursive: true, force: true })`
+
+## Files changed
+
+- `package.json`
+- `scripts/run-workspace-task.mjs`
+- `apps/cli/package.json`
+- `apps/worker/package.json`
+- `shannon`
+- `shannon.cmd`
+- `README.md`
+- `RUN_BLOCKER_FIXES.md`
+
+## Validation
+
+Validated successfully after patching:
+- `npm run clean`
+- `npm run build`
+- `npm run check`
+- `node shannon help`
+- `.\shannon.cmd help`
+
+## Remaining note
+
+`npm` still prints warnings from `.npmrc` because the repo contains `pnpm`-specific config keys:
+- `auto-install-peers`
+- `strict-peer-dependencies`
+- `minimum-release-age`
+
+That is non-blocking noise. It does not prevent build, check, clean, or launcher behavior after this patch.
+
+## Suggested PR title
+
+`Fix local run blockers for build/check/clean and Windows launcher`
+
+## Suggested owner review focus
+
+- whether replacing root `turbo` wrappers with a direct task runner is acceptable for local developer workflow
+- whether `shannon.cmd` should be kept as the supported Windows local entrypoint
+- whether `.npmrc` should be split or scoped to avoid `npm` warnings in mixed tool setups

--- a/README.md
+++ b/README.md
@@ -186,12 +186,14 @@ export ANTHROPIC_API_KEY="your-api-key"              # or CLAUDE_CODE_OAUTH_TOKE
 export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000           # recommended
 
 # 3. Install dependencies and build
-pnpm install
-pnpm build
+corepack pnpm install
+npm run build
 
 # 4. Run a pentest
 ./shannon start -u https://your-app.com -r /path/to/your-repo
 ```
+
+On Windows PowerShell or Command Prompt, use `.\shannon.cmd` instead of `./shannon`.
 
 Shannon will build the worker image locally, start the infrastructure, and launch an ephemeral worker container for the scan.
 

--- a/RUN_BLOCKER_FIXES.md
+++ b/RUN_BLOCKER_FIXES.md
@@ -1,0 +1,175 @@
+# Run Blocker Fixes
+
+## Summary
+
+This file documents the reproducible run blockers found in this repository, the fixes applied, and the validation performed after patching.
+
+Date checked: 2026-04-19
+Environment checked: Windows PowerShell, Node.js v24.14.1
+
+## Issues Found
+
+### 1. Root workspace commands failed before package code ran
+
+Affected commands:
+- `corepack pnpm build`
+- `corepack pnpm check`
+
+Observed failure:
+- `turbo` failed with `Unable to find package manager binary: cannot find binary path`
+
+Impact:
+- The documented root workflow could not build or check the monorepo from the repo root in this environment.
+
+Root cause:
+- Root scripts depended on `turbo run ...`, and `turbo` could not resolve the package-manager binary correctly in this setup.
+
+### 2. Local launcher behavior was broken for the repo entry script
+
+Affected file:
+- `shannon`
+
+Observed behavior:
+- `.\shannon help` in PowerShell produced no output.
+- `node shannon help` worked reliably.
+
+Impact:
+- The documented local clone entrypoint was unreliable, especially on Windows.
+
+Root cause:
+- The launcher used a dynamic import without awaiting it, which made the entry script fragile as a direct local launcher.
+
+### 3. Package clean scripts were Unix-only
+
+Affected files:
+- `apps/cli/package.json`
+- `apps/worker/package.json`
+
+Observed behavior:
+- `clean` scripts used `rm -rf dist`
+
+Impact:
+- Cleanup commands were not cross-platform and would fail on standard Windows shells.
+
+Root cause:
+- Shell scripts assumed a Unix environment.
+
+### 4. Windows local clone workflow was not explicitly supported at the repo root
+
+Impact:
+- PowerShell and Command Prompt users did not have a dedicated launcher path for local mode.
+
+Root cause:
+- The repo only had the `shannon` script and no Windows wrapper alongside it.
+
+## Patches Applied
+
+### Root task runner
+
+Added:
+- [scripts/run-workspace-task.mjs](H:\0 Cyber security\_PROJECTX\shannon-main\scripts\run-workspace-task.mjs)
+
+Changed:
+- [package.json](H:\0 Cyber security\_PROJECTX\shannon-main\package.json)
+
+Patch:
+- Replaced root `build`, `check`, and `clean` scripts so they no longer depend on `turbo`.
+- The new runner executes workspace tasks directly:
+  - worker build/check via TypeScript CLI
+  - cli build via `tsdown`
+  - clean via Node-based recursive delete
+
+Reason:
+- This removes the package-manager-resolution failure path and makes root commands work predictably in this environment.
+
+### Cross-platform clean scripts
+
+Changed:
+- [apps/cli/package.json](H:\0 Cyber security\_PROJECTX\shannon-main\apps\cli\package.json)
+- [apps/worker/package.json](H:\0 Cyber security\_PROJECTX\shannon-main\apps\worker\package.json)
+
+Patch:
+- Replaced `rm -rf dist` with:
+
+```bash
+node -e "import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))"
+```
+
+Reason:
+- Works on Windows and Unix without requiring shell-specific commands.
+
+### Local launcher fix
+
+Changed:
+- [shannon](H:\0 Cyber security\_PROJECTX\shannon-main\shannon)
+
+Patch:
+- Changed:
+
+```js
+import('./apps/cli/dist/index.mjs');
+```
+
+- To:
+
+```js
+await import('./apps/cli/dist/index.mjs');
+```
+
+Reason:
+- Ensures the local entrypoint waits for the CLI module to execute.
+
+### Windows launcher support
+
+Added:
+- [shannon.cmd](H:\0 Cyber security\_PROJECTX\shannon-main\shannon.cmd)
+
+Patch:
+- Added a Windows wrapper that sets `SHANNON_LOCAL=1` and runs the built CLI directly.
+
+Reason:
+- Gives PowerShell and Command Prompt a supported local entrypoint.
+
+### Documentation update
+
+Changed:
+- [README.md](H:\0 Cyber security\_PROJECTX\shannon-main\README.md)
+
+Patch:
+- Updated Clone and Build instructions to use:
+  - `corepack pnpm install`
+  - `npm run build`
+- Added Windows note:
+  - use `.\shannon.cmd` in PowerShell or Command Prompt
+
+Reason:
+- Aligns the docs with the patched local workflow.
+
+## Validation Performed
+
+Validated successfully after patching:
+- `npm run clean`
+- `npm run build`
+- `npm run check`
+- `node shannon help`
+- `.\shannon.cmd help`
+
+Observed remaining non-blocking issue:
+- `npm` prints warnings because [`.npmrc`](H:\0 Cyber security\_PROJECTX\shannon-main\.npmrc) contains `pnpm`-specific config keys:
+  - `auto-install-peers`
+  - `strict-peer-dependencies`
+  - `minimum-release-age`
+
+This is noise only. It does not block build, check, clean, or launcher behavior after the patch.
+
+## Current Status
+
+Fixed:
+- Root build/check/clean execution path
+- Cross-platform clean scripts
+- Local launcher reliability
+- Windows local launcher support
+
+Not addressed in this patch set:
+- Docker/Temporal runtime bugs inside the pentest pipeline
+- Any application-level logic bug beyond the run blockers above

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsdown",
     "check": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\""
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc",
     "check": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\""
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "catalog:",

--- a/package.json
+++ b/package.json
@@ -5,17 +5,18 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "build": "turbo run build",
-    "check": "turbo run check",
+    "build": "node scripts/run-workspace-task.mjs build",
+    "check": "node scripts/run-workspace-task.mjs check",
     "biome": "biome check .",
     "biome:fix": "biome check --write .",
-    "clean": "turbo run clean",
+    "clean": "node scripts/run-workspace-task.mjs clean",
     "temporal:worker": "node apps/worker/dist/temporal/worker.js",
     "temporal:start": "node apps/worker/dist/temporal/worker.js"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@types/node": "^25.0.3",
+    "pnpm": "^10.33.0",
     "turbo": "^2.5.0",
     "typescript": "^5.9.3"
   },

--- a/scripts/run-workspace-task.mjs
+++ b/scripts/run-workspace-task.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const task = process.argv[2];
+const cleanCommand = [process.execPath, ['-e', "import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))"]];
+const workspaceTasks = [
+  {
+    name: 'worker',
+    dir: 'apps/worker',
+    commands: {
+      build: [process.execPath, [path.resolve('node_modules/typescript/bin/tsc')]],
+      check: [process.execPath, [path.resolve('node_modules/typescript/bin/tsc'), '--noEmit']],
+      clean: cleanCommand,
+    },
+  },
+  {
+    name: 'cli',
+    dir: 'apps/cli',
+    commands: {
+      build: [process.execPath, [path.resolve('apps/cli/node_modules/tsdown/dist/run.mjs')]],
+      check: [process.execPath, [path.resolve('node_modules/typescript/bin/tsc'), '--noEmit']],
+      clean: cleanCommand,
+    },
+  },
+];
+
+if (!task) {
+  console.error('Usage: node scripts/run-workspace-task.mjs <build|check|clean>');
+  process.exit(1);
+}
+
+for (const workspace of workspaceTasks) {
+  const cwd = path.resolve(workspace.dir);
+  const command = workspace.commands[task];
+  if (!command) {
+    console.error(`Unsupported task: ${task}`);
+    process.exit(1);
+  }
+
+  console.log(`\n> ${workspace.name}:${task}`);
+
+  const [cmd, args] = command;
+  const result = spawnSync(cmd, args, {
+    cwd,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/shannon
+++ b/shannon
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 process.env.SHANNON_LOCAL = '1';
-import('./apps/cli/dist/index.mjs');
+await import('./apps/cli/dist/index.mjs');

--- a/shannon.cmd
+++ b/shannon.cmd
@@ -1,0 +1,3 @@
+@echo off
+set SHANNON_LOCAL=1
+node "%~dp0apps\cli\dist\index.mjs" %*


### PR DESCRIPTION
# Draft PR: Fix local run blockers for build/check/clean and Windows launcher

## What changed

This patch fixes a set of reproducible local run blockers in the Shannon monorepo.

Changes included:
- replace root `turbo`-based `build`, `check`, and `clean` wrappers with a direct workspace task runner
- replace Unix-only `rm -rf dist` cleanup scripts with cross-platform Node-based cleanup
- fix the local `shannon` launcher to await the CLI import
- add `shannon.cmd` for Windows PowerShell / Command Prompt local usage
- update clone/build docs in `README.md` to reflect the working local flow
- add `RUN_BLOCKER_FIXES.md` to document the issue, root cause, patch, and validation

## Why this changed

These issues were reproducible in a Windows PowerShell environment and blocked normal local use of the repository.

### Issue 1: root workspace commands failed

Observed failure:
- `corepack pnpm build`
- `corepack pnpm check`

Failure message:
- `turbo`: `Unable to find package manager binary: cannot find binary path`

Impact:
- monorepo build/check failed before package code ran

Patch:
- remove the dependency on root `turbo run ...` for the documented local build/check/clean path
- run workspace tasks directly from a repo-local script

### Issue 2: local launcher was unreliable

Observed behavior:
- `.\shannon help` did not behave reliably as a local entrypoint

Impact:
- local clone usage was fragile, especially on Windows

Patch:
- make the repo launcher explicitly await the dynamic CLI import
- add a Windows wrapper script: `shannon.cmd`

### Issue 3: clean scripts were Unix-only

Observed behavior:
- package `clean` scripts used `rm -rf dist`

Impact:
- clean failed on standard Windows shells

Patch:
- replace shell-specific cleanup with `fs.rmSync(..., { recursive: true, force: true })`

## Files changed

- `package.json`
- `scripts/run-workspace-task.mjs`
- `apps/cli/package.json`
- `apps/worker/package.json`
- `shannon`
- `shannon.cmd`
- `README.md`
- `RUN_BLOCKER_FIXES.md`

## Validation

Validated successfully after patching:
- `npm run clean`
- `npm run build`
- `npm run check`
- `node shannon help`
- `.\shannon.cmd help`

## Remaining note

`npm` still prints warnings from `.npmrc` because the repo contains `pnpm`-specific config keys:
- `auto-install-peers`
- `strict-peer-dependencies`
- `minimum-release-age`

That is non-blocking noise. It does not prevent build, check, clean, or launcher behavior after this patch.
