### PR TITLE
feat: add MiniMax-M2.7 support via router mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ ANTHROPIC_API_KEY=your-api-key-here
 # OPENROUTER_API_KEY=sk-or-your-openrouter-key
 # ROUTER_DEFAULT=openrouter,google/gemini-3-flash-preview
 
+# --- MiniMax ---
+# MINIMAX_API_KEY=your-minimax-key
+# ROUTER_DEFAULT=minimax,MiniMax-M2.7
+
 # =============================================================================
 # Model Tier Overrides (Anthropic API / OAuth / Custom Base URL / Bedrock)
 # =============================================================================
@@ -78,3 +82,4 @@ ANTHROPIC_API_KEY=your-api-key-here
 # =============================================================================
 # OpenAI:     gpt-5.2, gpt-5-mini
 # OpenRouter: google/gemini-3-flash-preview
+# MiniMax:    MiniMax-M2.7, MiniMax-Text-01

--- a/README.md
+++ b/README.md
@@ -545,17 +545,24 @@ ANTHROPIC_LARGE_MODEL=claude-opus-4-6
 
 Shannon can experimentally route requests through alternative AI providers using claude-code-router. This mode is not officially supported and is intended primarily for:
 
-- **Model experimentation** — try Shannon with GPT-5.2 or Gemini 3-family models
+- **Model experimentation** — try Shannon with GPT-5.2, Gemini 3-family models, or MiniMax-M2.7
 
 #### Quick Setup
 
-Run `npx @keygraph/shannon setup` and select **Router**. The wizard will prompt you to choose a provider (OpenAI or OpenRouter), enter your API key, and select a default model.
+Run `npx @keygraph/shannon setup` and select **Router**. The wizard will prompt you to choose a provider (OpenAI, OpenRouter, or MiniMax), enter your API key, and select a default model.
 
 Or export env vars directly:
 
 ```bash
 export OPENAI_API_KEY=sk-...          # or OPENROUTER_API_KEY=sk-or-...
 export ROUTER_DEFAULT=openai,gpt-5.2  # provider,model format
+```
+
+For MiniMax:
+
+```bash
+export MINIMAX_API_KEY=<your-minimax-key>
+export ROUTER_DEFAULT=minimax,MiniMax-M2.7
 ```
 
 ```bash
@@ -569,6 +576,8 @@ npx @keygraph/shannon start -u https://example.com -r /path/to/repo --router
 OPENAI_API_KEY=sk-...
 # OR
 OPENROUTER_API_KEY=sk-or-...
+# OR
+MINIMAX_API_KEY=<your-minimax-key>
 ROUTER_DEFAULT=openai,gpt-5.2
 ```
 
@@ -584,6 +593,7 @@ ROUTER_DEFAULT=openai,gpt-5.2
 |----------|--------|
 | OpenAI | gpt-5.2, gpt-5-mini |
 | OpenRouter | google/gemini-3-flash-preview |
+| MiniMax | MiniMax-M2.7, MiniMax-Text-01 |
 
 #### Disclaimer
 

--- a/apps/cli/infra/compose.yml
+++ b/apps/cli/infra/compose.yml
@@ -38,6 +38,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-openai,gpt-4o}
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3456/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]

--- a/apps/cli/infra/router-config.json
+++ b/apps/cli/infra/router-config.json
@@ -23,6 +23,15 @@
       "transformer": {
         "use": ["openrouter"]
       }
+    },
+    {
+      "name": "minimax",
+      "api_base_url": "https://api.minimaxi.chat/v1/chat/completions",
+      "api_key": "$MINIMAX_API_KEY",
+      "models": ["MiniMax-M2.7", "MiniMax-Text-01"],
+      "transformer": {
+        "use": []
+      }
     }
   ],
   "Router": {

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -288,12 +288,17 @@ async function setupRouter(): Promise<ShannonConfig> {
     options: [
       { value: 'openai' as const, label: 'OpenAI' },
       { value: 'openrouter' as const, label: 'OpenRouter' },
+      { value: 'minimax' as const, label: 'MiniMax', hint: 'experimental' },
     ],
   });
   if (p.isCancel(routerProvider)) return cancelAndExit();
 
   const apiKey = await promptSecret(
-    routerProvider === 'openai' ? 'Enter your OpenAI API key' : 'Enter your OpenRouter API key',
+    routerProvider === 'openai'
+      ? 'Enter your OpenAI API key'
+      : routerProvider === 'minimax'
+        ? 'Enter your MiniMax API key'
+        : 'Enter your OpenRouter API key',
   );
 
   let defaultModel: string;
@@ -307,6 +312,16 @@ async function setupRouter(): Promise<ShannonConfig> {
     });
     if (p.isCancel(model)) return cancelAndExit();
     defaultModel = `openai,${model}`;
+  } else if (routerProvider === 'minimax') {
+    const model = await p.select({
+      message: 'Default model',
+      options: [
+        { value: 'MiniMax-M2.7' as const, label: 'MiniMax-M2.7' },
+        { value: 'MiniMax-Text-01' as const, label: 'MiniMax-Text-01' },
+      ],
+    });
+    if (p.isCancel(model)) return cancelAndExit();
+    defaultModel = `minimax,${model}`;
   } else {
     const model = await p.select({
       message: 'Default model',
@@ -319,6 +334,8 @@ async function setupRouter(): Promise<ShannonConfig> {
   const router: ShannonConfig['router'] = { default: defaultModel };
   if (routerProvider === 'openai') {
     router.openai_key = apiKey;
+  } else if (routerProvider === 'minimax') {
+    router.minimax_key = apiKey;
   } else {
     router.openrouter_key = apiKey;
   }

--- a/apps/cli/src/config/resolver.ts
+++ b/apps/cli/src/config/resolver.ts
@@ -48,6 +48,7 @@ const CONFIG_MAP: readonly ConfigMapping[] = [
   { env: 'ROUTER_DEFAULT', toml: 'router.default', type: 'string' },
   { env: 'OPENAI_API_KEY', toml: 'router.openai_key', type: 'string' },
   { env: 'OPENROUTER_API_KEY', toml: 'router.openrouter_key', type: 'string' },
+  { env: 'MINIMAX_API_KEY', toml: 'router.minimax_key', type: 'string' },
 
   // Model tiers
   { env: 'ANTHROPIC_SMALL_MODEL', toml: 'models.small', type: 'string' },
@@ -170,8 +171,8 @@ function validateProviderFields(config: TOMLConfig, provider: string, errors: st
       if (!keys.includes('default')) {
         errors.push('[router] missing required key: default');
       }
-      if (!keys.includes('openai_key') && !keys.includes('openrouter_key')) {
-        errors.push('[router] requires either openai_key or openrouter_key');
+      if (!keys.includes('openai_key') && !keys.includes('openrouter_key') && !keys.includes('minimax_key')) {
+        errors.push('[router] requires one of: openai_key, openrouter_key, minimax_key');
       }
       const models = config.models as Record<string, unknown> | undefined;
       if (models && typeof models === 'object' && Object.keys(models).length > 0) {

--- a/apps/cli/src/config/writer.ts
+++ b/apps/cli/src/config/writer.ts
@@ -13,7 +13,7 @@ export interface ShannonConfig {
   custom_base_url?: { base_url?: string; auth_token?: string };
   bedrock?: { use?: boolean; region?: string; token?: string };
   vertex?: { use?: boolean; region?: string; project_id?: string; key_path?: string };
-  router?: { default?: string; openai_key?: string; openrouter_key?: string };
+  router?: { default?: string; openai_key?: string; openrouter_key?: string; minimax_key?: string };
   models?: { small?: string; medium?: string; large?: string };
 }
 

--- a/apps/cli/src/env.ts
+++ b/apps/cli/src/env.ts
@@ -29,6 +29,7 @@ const FORWARD_VARS = [
   'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
   'OPENAI_API_KEY',
   'OPENROUTER_API_KEY',
+  'MINIMAX_API_KEY',
 ] as const;
 
 /**
@@ -69,7 +70,10 @@ interface CredentialValidation {
 
 /** Check if router credentials are present in the environment. */
 export function isRouterConfigured(): boolean {
-  return !!(process.env.ROUTER_DEFAULT && (process.env.OPENAI_API_KEY || process.env.OPENROUTER_API_KEY));
+  return !!(
+    process.env.ROUTER_DEFAULT &&
+    (process.env.OPENAI_API_KEY || process.env.OPENROUTER_API_KEY || process.env.MINIMAX_API_KEY)
+  );
 }
 
 /** Check if a custom Anthropic-compatible base URL is configured. */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       - ROUTER_DEFAULT=${ROUTER_DEFAULT:-openai,gpt-4o}
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:3456/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]


### PR DESCRIPTION
## Summary

- Add MiniMax as an experimental router provider alongside OpenAI and OpenRouter
- Users can now run Shannon with MiniMax-M2.7 by setting `MINIMAX_API_KEY` and `ROUTER_DEFAULT=minimax,MiniMax-M2.7`
- MiniMax-M2.7 is a strong reasoning model with an OpenAI-compatible API at `api.minimaxi.chat`

## Changes

- **`apps/cli/infra/router-config.json`** — add `minimax` provider entry with MiniMax-M2.7 and MiniMax-Text-01 models
- **`apps/cli/src/env.ts`** — add `MINIMAX_API_KEY` to `FORWARD_VARS`; update `isRouterConfigured()` to accept `MINIMAX_API_KEY`
- **`apps/cli/src/config/resolver.ts`** — add `router.minimax_key` TOML mapping and update router validation to accept `minimax_key`
- **`apps/cli/src/config/writer.ts`** — add `minimax_key` to `ShannonConfig.router` type
- **`apps/cli/src/commands/setup.ts`** — add MiniMax option in the interactive setup wizard router flow
- **`docker-compose.yml`** and **`apps/cli/infra/compose.yml`** — pass `MINIMAX_API_KEY` through to the router container
- **`.env.example`** — document `MINIMAX_API_KEY` / `ROUTER_DEFAULT=minimax,MiniMax-M2.7` usage
- **`README.md`** — add MiniMax to the Router Mode section and experimental models table

## Test plan

- [ ] Run `npx @keygraph/shannon setup`, select Router → MiniMax, enter API key, confirm `~/.shannon/config.toml` has correct `[router]` section
- [ ] Export `MINIMAX_API_KEY=<key>` and `ROUTER_DEFAULT=minimax,MiniMax-M2.7`, run `./shannon start --router`, verify router starts and routes to MiniMax
- [ ] Confirm TypeScript check passes: `pnpm run check`
- [ ] Confirm Biome check passes on changed files: `pnpm exec biome check apps/cli/src/`