### PR TITLE
fix(worker): make deliverable saving resilient for large recon reports

### DIFF
--- a/apps/worker/prompts/recon.txt
+++ b/apps/worker/prompts/recon.txt
@@ -379,6 +379,17 @@ CRITICAL: Only include sources tracing to dangerous sinks (shell, DB, file ops, 
 
 **WARNING:** Do NOT write the entire report in a single tool call — exceeds 32K output token limit. Split into multiple Write/Edit operations. Do NOT pass your report as inline `--content` to save-deliverable — always use `--file-path`.
 
+**FALLBACK FOR LARGE FILE WRITE FAILURES:** If Write/Edit fails due to file size, use **Bash** to append safely in chunks:
+- Initialize once: `mkdir -p .shannon/deliverables && : > .shannon/deliverables/recon_deliverable.md`
+- Append each section with a heredoc (repeat section-by-section):
+  ```bash
+  cat <<'EOF' >> .shannon/deliverables/recon_deliverable.md
+  ## <Section Title>
+  <section content>
+  EOF
+  ```
+- Then run `save-deliverable --type RECON --file-path ".shannon/deliverables/recon_deliverable.md"`
+
 Once the deliverable is successfully saved, announce "RECONNAISSANCE COMPLETE" and stop.
 
 **CRITICAL:** After announcing completion, STOP IMMEDIATELY. Do NOT output summaries, recaps, or explanations of your work — the deliverable contains everything needed.

--- a/apps/worker/src/scripts/save-deliverable.ts
+++ b/apps/worker/src/scripts/save-deliverable.ts
@@ -15,7 +15,7 @@
  *   node save-deliverable.js --type INJECTION_ANALYSIS --file-path deliverables/injection_analysis_deliverable.md
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { accessSync, constants, copyFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { DELIVERABLE_FILENAMES, type DeliverableType } from '../types/deliverables.js';
 
@@ -51,7 +51,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 // === File Operations ===
 
-function saveDeliverableFile(targetDir: string, filename: string, content: string): string {
+function resolveDeliverablePath(targetDir: string, filename: string): string {
   const subdir = process.env.SHANNON_DELIVERABLES_SUBDIR || '.shannon/deliverables';
   const deliverablesDir = join(targetDir, ...subdir.split('/'));
   const filepath = join(deliverablesDir, filename);
@@ -62,7 +62,22 @@ function saveDeliverableFile(targetDir: string, filename: string, content: strin
     throw new Error(`Cannot create deliverables directory at ${deliverablesDir}`);
   }
 
+  return filepath;
+}
+
+function saveDeliverableFile(targetDir: string, filename: string, content: string): string {
+  const filepath = resolveDeliverablePath(targetDir, filename);
   writeFileSync(filepath, content, 'utf8');
+  return filepath;
+}
+
+function saveDeliverableFromFile(targetDir: string, filename: string, sourcePath: string): string {
+  const filepath = resolveDeliverablePath(targetDir, filename);
+
+  if (sourcePath !== filepath) {
+    copyFileSync(sourcePath, filepath);
+  }
+
   return filepath;
 }
 
@@ -87,30 +102,41 @@ function main(): void {
     process.exit(1);
   }
 
-  // 2. Resolve content from --content or --file-path
-  let content: string;
+  // 2. Save from --content or --file-path
+  try {
+    const targetDir = process.cwd();
 
-  if (args.content) {
-    content = args.content;
-  } else if (args.filePath) {
-    // Path traversal protection: must resolve inside cwd
-    const cwd = process.cwd();
-    const resolved = resolve(cwd, args.filePath);
-    if (!resolved.startsWith(`${cwd}/`) && resolved !== cwd) {
-      console.log(
-        JSON.stringify({ status: 'error', message: `Path traversal detected: ${args.filePath}`, retryable: false }),
-      );
-      process.exit(1);
+    if (args.content) {
+      const filepath = saveDeliverableFile(targetDir, filename, args.content);
+      console.log(JSON.stringify({ status: 'success', filepath }));
+      return;
     }
 
-    try {
-      content = readFileSync(resolved, 'utf8');
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      console.log(JSON.stringify({ status: 'error', message: `Failed to read file: ${msg}`, retryable: true }));
-      process.exit(1);
+    if (args.filePath) {
+      // Path traversal protection: must resolve inside cwd
+      const cwd = process.cwd();
+      const resolved = resolve(cwd, args.filePath);
+      if (!resolved.startsWith(`${cwd}/`) && resolved !== cwd) {
+        console.log(
+          JSON.stringify({ status: 'error', message: `Path traversal detected: ${args.filePath}`, retryable: false }),
+        );
+        process.exit(1);
+      }
+
+      // Validate file is readable before copy for clearer errors
+      try {
+        accessSync(resolved, constants.R_OK);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        console.log(JSON.stringify({ status: 'error', message: `Failed to read file: ${msg}`, retryable: true }));
+        process.exit(1);
+      }
+
+      const filepath = saveDeliverableFromFile(targetDir, filename, resolved);
+      console.log(JSON.stringify({ status: 'success', filepath }));
+      return;
     }
-  } else {
+
     console.log(
       JSON.stringify({
         status: 'error',
@@ -119,13 +145,6 @@ function main(): void {
       }),
     );
     process.exit(1);
-  }
-
-  // 3. Save the file
-  try {
-    const targetDir = process.cwd();
-    const filepath = saveDeliverableFile(targetDir, filename, content);
-    console.log(JSON.stringify({ status: 'success', filepath }));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     console.log(JSON.stringify({ status: 'error', message: `Failed to save: ${msg}`, retryable: true }));


### PR DESCRIPTION
### Motivation
- Fix failures when very large recon reports exceed the agent Write/Edit size limits by providing a robust fallback write workflow and avoiding large in-memory copies.
- Reduce memory usage and improve stability of the `save-deliverable` CLI when saving from `--file-path` (addresses issue #300).

### Description
- Add explicit fallback instructions to the recon prompt `apps/worker/prompts/recon.txt` that show chunked Bash heredoc append steps and then call `save-deliverable --type RECON --file-path ".shannon/deliverables/recon_deliverable.md"` so agents can persist very large reports safely.
- Refactor `apps/worker/src/scripts/save-deliverable.ts` to introduce `resolveDeliverablePath`, `saveDeliverableFile`, and `saveDeliverableFromFile` helpers and to use `copyFileSync` for the `--file-path` code path instead of reading the entire source into memory.
- Add a readability check using `accessSync(..., constants.R_OK)` and keep existing path-traversal protections when handling `--file-path` to provide clearer errors and preserve safety.

### Testing
- Ran `pnpm --filter @shannon/worker check` (runs `tsc --noEmit`) and the TypeScript typecheck completed successfully.

