### PR TITLE
[Security] Scope git safe.directory to specific paths (closes #316)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,9 @@ RUN addgroup -g 1001 pentest && \
 # System-level git config (survives UID remapping in entrypoint)
 RUN git config --system user.email "agent@localhost" && \
     git config --system user.name "Pentest Agent" && \
-    git config --system --add safe.directory '*'
+    git config --system --add safe.directory /app/repos && \
+    git config --system --add safe.directory /app/workspaces && \
+    git config --system --add safe.directory /app/sessions
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary

Replaces the unsafe wildcard git configuration with scoped paths that Shannon worker actually uses.

## Changes
- Scoped git's `safe.directory` config from `'*'` to specific application paths:
  - `/app/repos` - Repository clones
  - `/app/workspaces` - Workspace data
  - `/app/sessions` - Session data

## Security Impact
- Preserves CVE-2022-24765 ownership protections for all other directories
- Prevents malicious repositories from bypassing git's security checks
- Maintains worker functionality while reducing attack surface

## References
- Closes #316
- CVE-2022-24765