### PR TITLE
feat: add OpenRouter as a first-class AI provider

### DIFF
--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -13,7 +13,7 @@ import { type ShannonConfig, saveConfig } from '../config/writer.js';
 
 const SHANNON_HOME = path.join(os.homedir(), '.shannon');
 
-type Provider = 'anthropic' | 'custom_base_url' | 'bedrock' | 'vertex';
+type Provider = 'anthropic' | 'openrouter' | 'custom_base_url' | 'bedrock' | 'vertex';
 
 export async function setup(): Promise<void> {
   p.intro('Shannon Setup');
@@ -23,6 +23,7 @@ export async function setup(): Promise<void> {
     message: 'Select your AI provider',
     options: [
       { value: 'anthropic' as const, label: 'Claude Direct', hint: 'recommended' },
+      { value: 'openrouter' as const, label: 'OpenRouter' },
       { value: 'custom_base_url' as const, label: 'Custom Base URL', hint: 'proxies, gateways' },
       { value: 'bedrock' as const, label: 'Claude via AWS Bedrock' },
       { value: 'vertex' as const, label: 'Claude via Google Vertex AI' },
@@ -44,6 +45,8 @@ async function setupProvider(provider: Provider): Promise<ShannonConfig> {
   switch (provider) {
     case 'anthropic':
       return setupAnthropic();
+    case 'openrouter':
+      return setupOpenRouter();
     case 'custom_base_url':
       return setupCustomBaseUrl();
     case 'bedrock':
@@ -103,6 +106,51 @@ async function setupAnthropic(): Promise<ShannonConfig> {
     const large = await p.text({
       message: 'Large model ID',
       initialValue: 'claude-opus-4-6',
+      validate: required('Large model ID is required'),
+    });
+    if (p.isCancel(large)) return cancelAndExit();
+
+    config.models = { small, medium, large };
+  }
+
+  return config;
+}
+
+async function setupOpenRouter(): Promise<ShannonConfig> {
+  const apiKey = await promptSecret('Enter your OpenRouter API key');
+
+  const config: ShannonConfig = {
+    openrouter: { api_key: apiKey },
+  };
+
+  const customizeModels = await p.confirm({
+    message:
+      'Do you want to change the default models?\n' +
+      '    Small  - anthropic/claude-haiku-4-5-20251001\n' +
+      '    Medium - anthropic/claude-sonnet-4-6\n' +
+      '    Large  - anthropic/claude-opus-4-6',
+    initialValue: false,
+  });
+  if (p.isCancel(customizeModels)) return cancelAndExit();
+
+  if (customizeModels) {
+    const small = await p.text({
+      message: 'Small model ID',
+      initialValue: 'anthropic/claude-haiku-4-5-20251001',
+      validate: required('Small model ID is required'),
+    });
+    if (p.isCancel(small)) return cancelAndExit();
+
+    const medium = await p.text({
+      message: 'Medium model ID',
+      initialValue: 'anthropic/claude-sonnet-4-6',
+      validate: required('Medium model ID is required'),
+    });
+    if (p.isCancel(medium)) return cancelAndExit();
+
+    const large = await p.text({
+      message: 'Large model ID',
+      initialValue: 'anthropic/claude-opus-4-6',
       validate: required('Large model ID is required'),
     });
     if (p.isCancel(large)) return cancelAndExit();

--- a/apps/cli/src/config/resolver.ts
+++ b/apps/cli/src/config/resolver.ts
@@ -29,6 +29,9 @@ const CONFIG_MAP: readonly ConfigMapping[] = [
   { env: 'ANTHROPIC_API_KEY', toml: 'anthropic.api_key', type: 'string' },
   { env: 'CLAUDE_CODE_OAUTH_TOKEN', toml: 'anthropic.oauth_token', type: 'string' },
 
+  // OpenRouter
+  { env: 'OPENROUTER_API_KEY', toml: 'openrouter.api_key', type: 'string' },
+
   // Bedrock
   { env: 'CLAUDE_CODE_USE_BEDROCK', toml: 'bedrock.use', type: 'boolean' },
   { env: 'AWS_REGION', toml: 'bedrock.region', type: 'string' },
@@ -132,6 +135,15 @@ function validateProviderFields(config: TOMLConfig, provider: string, errors: st
       }
       break;
 
+    case 'openrouter': {
+      const required = ['api_key'];
+      const missing = required.filter((k) => !keys.includes(k));
+      if (missing.length > 0) {
+        errors.push(`[openrouter] missing required keys: ${missing.join(', ')}`);
+      }
+      break;
+    }
+
     case 'custom_base_url': {
       const required = ['base_url', 'auth_token'];
       const missing = required.filter((k) => !keys.includes(k));
@@ -223,7 +235,7 @@ function validateConfig(config: TOMLConfig): string[] {
   }
 
   // 4. Only one provider section allowed (ignore empty sections)
-  const PROVIDER_SECTIONS = ['anthropic', 'custom_base_url', 'bedrock', 'vertex'] as const;
+  const PROVIDER_SECTIONS = ['anthropic', 'openrouter', 'custom_base_url', 'bedrock', 'vertex'] as const;
   const present = PROVIDER_SECTIONS.filter((s) => {
     const section = config[s];
     return section && typeof section === 'object' && Object.keys(section).length > 0;

--- a/apps/cli/src/config/writer.ts
+++ b/apps/cli/src/config/writer.ts
@@ -10,6 +10,7 @@ import { getConfigFile } from '../home.js';
 export interface ShannonConfig {
   core?: { max_tokens?: number };
   anthropic?: { api_key?: string; oauth_token?: string };
+  openrouter?: { api_key?: string };
   custom_base_url?: { base_url?: string; auth_token?: string };
   bedrock?: { use?: boolean; region?: string; token?: string };
   vertex?: { use?: boolean; region?: string; project_id?: string; key_path?: string };

--- a/apps/cli/src/env.ts
+++ b/apps/cli/src/env.ts
@@ -15,6 +15,7 @@ const FORWARD_VARS = [
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
   'CLAUDE_CODE_OAUTH_TOKEN',
+  'OPENROUTER_API_KEY',
   'CLAUDE_CODE_USE_BEDROCK',
   'AWS_REGION',
   'AWS_BEARER_TOKEN_BEDROCK',
@@ -61,7 +62,7 @@ export function buildEnvFlags(): string[] {
 interface CredentialValidation {
   valid: boolean;
   error?: string;
-  mode: 'api-key' | 'oauth' | 'custom-base-url' | 'bedrock' | 'vertex';
+  mode: 'api-key' | 'oauth' | 'openrouter' | 'custom-base-url' | 'bedrock' | 'vertex';
 }
 
 /** Check if a custom Anthropic-compatible base URL is configured. */
@@ -74,6 +75,7 @@ function detectProviders(): string[] {
   const providers: string[] = [];
   if (process.env.ANTHROPIC_API_KEY) providers.push('Anthropic API key');
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) providers.push('Anthropic OAuth');
+  if (process.env.OPENROUTER_API_KEY) providers.push('OpenRouter');
   if (isCustomBaseUrlConfigured()) providers.push('Custom Base URL');
   if (process.env.CLAUDE_CODE_USE_BEDROCK === '1') providers.push('AWS Bedrock');
   if (process.env.CLAUDE_CODE_USE_VERTEX === '1') providers.push('Google Vertex');
@@ -99,6 +101,9 @@ export function validateCredentials(): CredentialValidation {
   }
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
     return { valid: true, mode: 'oauth' };
+  }
+  if (process.env.OPENROUTER_API_KEY) {
+    return { valid: true, mode: 'openrouter' };
   }
   if (isCustomBaseUrlConfigured()) {
     return { valid: true, mode: 'custom-base-url' };

--- a/apps/worker/src/ai/claude-executor.ts
+++ b/apps/worker/src/ai/claude-executor.ts
@@ -183,6 +183,10 @@ export async function runClaudePrompt(
         if (providerConfig.baseUrl) sdkEnv.ANTHROPIC_BASE_URL = providerConfig.baseUrl;
         if (providerConfig.authToken) sdkEnv.ANTHROPIC_AUTH_TOKEN = providerConfig.authToken;
         break;
+      case 'openrouter':
+        sdkEnv.ANTHROPIC_BASE_URL = 'https://openrouter.ai/api/v1';
+        if (providerConfig.apiKey) sdkEnv.ANTHROPIC_API_KEY = providerConfig.apiKey;
+        break;
       default:
         // 'anthropic_api' or unset — apiKey already handled above
         if (providerConfig.apiKey && !apiKey) sdkEnv.ANTHROPIC_API_KEY = providerConfig.apiKey;

--- a/apps/worker/src/services/preflight.ts
+++ b/apps/worker/src/services/preflight.ts
@@ -197,7 +197,38 @@ async function validateCredentials(logger: ActivityLogger, apiKey?: string, prov
   if (apiKey) {
     process.env.ANTHROPIC_API_KEY = apiKey;
   }
-  // 1. Custom base URL — validate endpoint is reachable via SDK query
+  // 1a. OpenRouter mode — validate required credentials are present
+  if (process.env.OPENROUTER_API_KEY) {
+    const baseUrl = 'https://openrouter.ai/api/v1';
+    logger.info(`Validating OpenRouter configuration: ${baseUrl}`);
+
+    try {
+      for await (const message of query({ prompt: 'hi', options: { model: resolveModel('small'), maxTurns: 1 } })) {
+        if (message.type === 'assistant' && message.error) {
+          return classifySdkError(message.error, 'OpenRouter endpoint');
+        }
+        if (message.type === 'result') {
+          break;
+        }
+      }
+
+      logger.info('OpenRouter OK');
+      return ok(undefined);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return err(
+        new PentestError(
+          `OpenRouter unreachable: ${msg}`,
+          'network',
+          false,
+          {},
+          ErrorCode.AUTH_FAILED,
+        ),
+      );
+    }
+  }
+
+  // 1b. Custom base URL — validate endpoint is reachable via SDK query
   if (process.env.ANTHROPIC_BASE_URL && process.env.ANTHROPIC_AUTH_TOKEN) {
     const baseUrl = process.env.ANTHROPIC_BASE_URL;
     logger.info(`Validating custom base URL: ${baseUrl}`);
@@ -305,7 +336,7 @@ async function validateCredentials(logger: ActivityLogger, apiKey?: string, prov
   }
 
   // 4. Check that at least one credential is present
-  if (!process.env.ANTHROPIC_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_AUTH_TOKEN) {
+  if (!process.env.ANTHROPIC_API_KEY && !process.env.CLAUDE_CODE_OAUTH_TOKEN && !process.env.ANTHROPIC_AUTH_TOKEN && !process.env.OPENROUTER_API_KEY) {
     return err(
       new PentestError(
         'No API credentials found. Set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN in .env (or use CLAUDE_CODE_USE_BEDROCK=1 for AWS Bedrock, or CLAUDE_CODE_USE_VERTEX=1 for Google Vertex AI)',


### PR DESCRIPTION
## Summary

Add OpenRouter support as a first-class provider across the full config stack, enabling Shannon users to route Claude Agent SDK requests through OpenRouter's API.

## Changes

### CLI (apps/cli)
- **setup.ts**: Added OpenRouter provider option to the interactive setup wizard with API key input. Default model prefixes use OpenRouter's `anthropic/` naming convention, fully customizable during setup.
- **writer.ts**: Added `openrouter` section to `ShannonConfig` interface.
- **resolver.ts**: Mapped `OPENROUTER_API_KEY` env var to TOML config, added provider validation, included in multi-provider detection.
- **env.ts**: Added `OPENROUTER_API_KEY` to forwarded env vars, provider detection, and credential validation.

### Worker (apps/worker)
- **claude-executor.ts**: Added `openrouter` case in the `providerConfig` switch — sets `ANTHROPIC_BASE_URL=https://openrouter.ai/api/v1` and forwards the API key to the SDK subprocess.
- **preflight.ts**: Added OpenRouter-specific credential validation flow (connectivity test via minimal SDK query) and included in the final credential presence check.

## How It Works

OpenRouter provides an Anthropic-compatible API endpoint. When selected:
- `ANTHROPIC_BASE_URL` is set to `https://openrouter.ai/api/v1`
- `ANTHROPIC_API_KEY` receives the OpenRouter API key
- Model IDs default to OpenRouter's `anthropic/claude-*` format but are fully customizable
- The Claude Agent SDK transparently routes through OpenRouter

## Usage

```bash
# Via setup wizard
npx @keygraph/shannon setup  # Select "OpenRouter", enter API key

# Or via environment
export OPENROUTER_API_KEY=sk-or-v1-...\nexport ANTHROPIC_SMALL_MODEL=anthropic/claude-haiku-4-5-20251001\nexport ANTHROPIC_MEDIUM_MODEL=anthropic/claude-sonnet-4-6
export ANTHROPIC_LARGE_MODEL=anthropic/claude-opus-4-6

npx @keygraph/shannon start -u https://example.com -r my-repo
```

## Testing
- Build passes (both worker + CLI packages)
- Type checking passes
- No runtime errors in compiled output