### PR TITLE
feat(cli): add DeepSeek provider via embedded LiteLLM proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,20 @@ ANTHROPIC_API_KEY=your-api-key-here
 # CLOUD_ML_REGION=us-east5
 # ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id
 # GOOGLE_APPLICATION_CREDENTIALS=./credentials/google-sa-key.json
+
+# =============================================================================
+# OPTION 5: DeepSeek (via embedded LiteLLM proxy)
+# =============================================================================
+# Setting DEEPSEEK_API_KEY here switches Shannon into "DeepSeek mode":
+#   - The `shannon-litellm` container starts automatically on shannon-net.
+#   - The worker is auto-pointed at http://shannon-litellm:4000 (Anthropic-
+#     compatible endpoint), with ANTHROPIC_AUTH_TOKEN derived from
+#     LITELLM_MASTER_KEY, and ANTHROPIC_*_MODEL set to the shannon-* aliases.
+#   - The model aliases are defined in apps/cli/infra/litellm-config.yaml
+#     and map to deepseek/deepseek-chat (small/medium) and
+#     deepseek/deepseek-reasoner (large).
+# Caveat: Shannon's prompts are tuned for Claude. Pentest quality on DeepSeek
+# is not guaranteed.
+
+# DEEPSEEK_API_KEY=your-deepseek-key
+# LITELLM_MASTER_KEY=sk-shannon-pick-any-strong-random-string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,11 +111,13 @@ Published as `@keygraph/shannon` on npm. Contains only Docker orchestration logi
 - `shannon` — Node.js entry point (`#!/usr/bin/env node`) that delegates to `apps/cli/dist/index.mjs`
 
 ### Docker Architecture
-Infra (Temporal) runs via `docker-compose.yml`. Workers are ephemeral `docker run --rm` containers, one per scan, each with a unique task queue and isolated volume mounts.
+Infra (Temporal, optionally LiteLLM) runs via `docker-compose.yml`. Workers are ephemeral `docker run --rm` containers, one per scan, each with a unique task queue and isolated volume mounts.
 
-- `docker-compose.yml` — Infra only: `shannon-temporal` (port 7233/8233). Network: `shannon-net`
+- `docker-compose.yml` — Infra: `shannon-temporal` (port 7233/8233) and `shannon-litellm` (gated by the `deepseek` compose profile, port 4000 on `shannon-net` only). Network: `shannon-net`
+- `apps/cli/infra/litellm-config.yaml` — LiteLLM model mapping. Exposes `shannon-small` / `shannon-medium` / `shannon-large` aliases that route to DeepSeek. Mounted into the proxy container by both compose files.
 - `Dockerfile` — 2-stage build (builder + Chainguard Wolfi runtime). Uses pnpm. Entrypoint: `CMD ["node", "apps/worker/dist/temporal/worker.js"]`
 - No `docker-compose.docker.yml` — host gateway handled via `--add-host` flag in CLI
+- DeepSeek mode is auto-detected via `DEEPSEEK_API_KEY` in `apps/cli/src/env.ts:isDeepseekMode`. When active, the CLI adds `--profile deepseek` to compose, and derives `ANTHROPIC_BASE_URL=http://shannon-litellm:4000`, `ANTHROPIC_AUTH_TOKEN=$LITELLM_MASTER_KEY`, and `ANTHROPIC_*_MODEL=shannon-*` for the worker — so the Claude Agent SDK transparently talks to the proxy.
 
 ### Worker Package (`apps/worker/`)
 - `apps/worker/src/paths.ts` — Centralized path constants (`PROMPTS_DIR`, `CONFIGS_DIR`, `WORKSPACES_DIR`)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Shannon Pro supports a self-hosted runner model (similar to GitHub Actions self-
   - [AWS Bedrock](#aws-bedrock)
   - [Google Vertex AI](#google-vertex-ai)
   - [Custom Base URL](#custom-base-url)
+  - [DeepSeek (experimental)](#deepseek-experimental)
   - [Platform-Specific Instructions](#platform-specific-instructions)
   - [Output and Results](#output-and-results)
 - [Sample Reports](#sample-reports)
@@ -577,6 +578,30 @@ ANTHROPIC_LARGE_MODEL=claude-opus-4-7
 ```
 
 </details>
+
+### DeepSeek (experimental)
+
+Shannon can route requests to [DeepSeek](https://platform.deepseek.com) instead of Anthropic via an embedded [LiteLLM](https://github.com/BerriAI/litellm) proxy. When DeepSeek mode is active, the `shannon-litellm` container starts automatically on `shannon-net` and translates Anthropic-format requests to DeepSeek's OpenAI-compatible chat completions API.
+
+> [!WARNING]
+> **This path is experimental and unsupported.** Shannon's prompts, evaluations, and agent harness are tuned for Claude. DeepSeek's tool-calling and reasoning behave differently — pentest quality may degrade, and some features (prompt caching, adaptive thinking) are silently dropped. Use at your own risk; do not rely on results for production security decisions.
+
+Run `npx @keygraph/shannon setup` and select **DeepSeek**. The wizard prompts for your DeepSeek API key and generates a master key for the local proxy.
+
+Or configure manually in `.env` (Clone and Build mode):
+
+```bash
+DEEPSEEK_API_KEY=your-deepseek-key
+LITELLM_MASTER_KEY=sk-shannon-pick-any-strong-random-string
+```
+
+With those two vars set, the CLI:
+
+- Starts the `shannon-litellm` container automatically (via the `deepseek` compose profile).
+- Auto-sets `ANTHROPIC_BASE_URL=http://shannon-litellm:4000`, `ANTHROPIC_AUTH_TOKEN=$LITELLM_MASTER_KEY`, and the three `ANTHROPIC_*_MODEL` vars to the `shannon-small` / `shannon-medium` / `shannon-large` aliases.
+- Routes them through the proxy to `deepseek/deepseek-chat` (small/medium) and `deepseek/deepseek-reasoner` (large).
+
+The model aliases are defined in [`apps/cli/infra/litellm-config.yaml`](apps/cli/infra/litellm-config.yaml). Edit that file to map tiers to different DeepSeek models or add new aliases.
 
 ### Platform-Specific Instructions
 

--- a/apps/cli/infra/compose.yml
+++ b/apps/cli/infra/compose.yml
@@ -19,5 +19,24 @@ services:
       retries: 10
       start_period: 30s
 
+  # LiteLLM proxy — see docker-compose.yml at the repo root for the local-mode
+  # equivalent. Only started when the `deepseek` compose profile is enabled.
+  litellm:
+    image: ghcr.io/berriai/litellm:main-stable
+    container_name: shannon-litellm
+    profiles: ["deepseek"]
+    command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    environment:
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
+    volumes:
+      - ./litellm-config.yaml:/etc/litellm/config.yaml:ro
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
 volumes:
   temporal-data:

--- a/apps/cli/infra/compose.yml
+++ b/apps/cli/infra/compose.yml
@@ -26,6 +26,8 @@ services:
     container_name: shannon-litellm
     profiles: ["deepseek"]
     command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    ports:
+      - "127.0.0.1:4000:4000"   # localhost-only — for debugging via curl
     environment:
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}

--- a/apps/cli/infra/litellm-config.yaml
+++ b/apps/cli/infra/litellm-config.yaml
@@ -1,0 +1,32 @@
+# LiteLLM proxy configuration for Shannon → DeepSeek routing.
+#
+# The Claude Agent SDK in the worker speaks Anthropic Messages API. LiteLLM's
+# proxy accepts those requests at /v1/messages and translates them to
+# DeepSeek's OpenAI-compatible chat completions endpoint.
+#
+# The three model_name entries here mirror Shannon's small / medium / large
+# tiers and match the ANTHROPIC_*_MODEL values written by the setup wizard.
+#
+# Reference: https://docs.litellm.ai/docs/proxy/configs
+
+model_list:
+  - model_name: shannon-small
+    litellm_params:
+      model: deepseek/deepseek-chat
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+  - model_name: shannon-medium
+    litellm_params:
+      model: deepseek/deepseek-chat
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+  - model_name: shannon-large
+    litellm_params:
+      model: deepseek/deepseek-reasoner
+      api_key: os.environ/DEEPSEEK_API_KEY
+
+litellm_settings:
+  drop_params: true
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/cli/infra/litellm-config.yaml
+++ b/apps/cli/infra/litellm-config.yaml
@@ -8,17 +8,35 @@
 # tiers and match the ANTHROPIC_*_MODEL values written by the setup wizard.
 #
 # Reference: https://docs.litellm.ai/docs/proxy/configs
+#
+# IMPORTANT: `extra_body.thinking.type=disabled` is required on the chat-tier
+# models. DeepSeek V4 enables hybrid thinking by default on `deepseek-chat`,
+# and once the upstream returns `reasoning_content` on any turn, every
+# subsequent multi-turn request must echo it back or DeepSeek rejects the
+# request with HTTP 400 "reasoning_content in the thinking mode must be passed
+# back". LiteLLM strips `reasoning_content` during Anthropic↔OpenAI translation
+# (BerriAI/litellm#26395, fix in flight in PR #26660 but not yet released).
+# Disabling thinking sidesteps the bug entirely without losing tool-calling
+# quality on the chat tier. The large tier stays on `deepseek-reasoner` (R1),
+# which uses the older "reasoning_content must NOT be passed back" contract
+# that LiteLLM handles correctly.
 
 model_list:
   - model_name: shannon-small
     litellm_params:
       model: deepseek/deepseek-chat
       api_key: os.environ/DEEPSEEK_API_KEY
+      extra_body:
+        thinking:
+          type: disabled
 
   - model_name: shannon-medium
     litellm_params:
       model: deepseek/deepseek-chat
       api_key: os.environ/DEEPSEEK_API_KEY
+      extra_body:
+        thinking:
+          type: disabled
 
   - model_name: shannon-large
     litellm_params:

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -5,6 +5,7 @@
  * then persists everything to ~/.shannon/config.toml with 0o600 permissions.
  */
 
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,7 +14,7 @@ import { type ShannonConfig, saveConfig } from '../config/writer.js';
 
 const SHANNON_HOME = path.join(os.homedir(), '.shannon');
 
-type Provider = 'anthropic' | 'custom_base_url' | 'bedrock' | 'vertex';
+type Provider = 'anthropic' | 'deepseek' | 'custom_base_url' | 'bedrock' | 'vertex';
 
 export async function setup(): Promise<void> {
   p.intro('Shannon Setup');
@@ -23,6 +24,7 @@ export async function setup(): Promise<void> {
     message: 'Select your AI provider',
     options: [
       { value: 'anthropic' as const, label: 'Claude Direct', hint: 'recommended' },
+      { value: 'deepseek' as const, label: 'DeepSeek', hint: 'via embedded LiteLLM proxy' },
       { value: 'custom_base_url' as const, label: 'Custom Base URL', hint: 'proxies, gateways' },
       { value: 'bedrock' as const, label: 'Claude via AWS Bedrock' },
       { value: 'vertex' as const, label: 'Claude via Google Vertex AI' },
@@ -47,6 +49,8 @@ async function setupProvider(provider: Provider): Promise<ShannonConfig> {
   switch (provider) {
     case 'anthropic':
       return setupAnthropic();
+    case 'deepseek':
+      return setupDeepseek();
     case 'custom_base_url':
       return setupCustomBaseUrl();
     case 'bedrock':
@@ -54,6 +58,66 @@ async function setupProvider(provider: Provider): Promise<ShannonConfig> {
     case 'vertex':
       return setupVertex();
   }
+}
+
+async function setupDeepseek(): Promise<ShannonConfig> {
+  p.log.info(
+    'Shannon will route requests through an embedded LiteLLM proxy on shannon-net.\n' +
+      'The proxy translates Anthropic-format requests to DeepSeek and starts automatically.',
+  );
+
+  const apiKey = await promptSecret('Enter your DeepSeek API key (from https://platform.deepseek.com)');
+
+  // Generate a master key for the local LiteLLM proxy. The worker authenticates
+  // to the proxy with this key (as ANTHROPIC_AUTH_TOKEN); the proxy enforces it
+  // server-side. Prefix is informational only.
+  const masterKey = `sk-shannon-${crypto.randomBytes(16).toString('hex')}`;
+
+  const config: ShannonConfig = {
+    deepseek: { api_key: apiKey, master_key: masterKey },
+  };
+
+  const customizeModels = await p.confirm({
+    message:
+      'Override the default DeepSeek model mapping?\n' +
+      '    Small  - shannon-small  (→ deepseek/deepseek-chat)\n' +
+      '    Medium - shannon-medium (→ deepseek/deepseek-chat)\n' +
+      '    Large  - shannon-large  (→ deepseek/deepseek-reasoner)',
+    initialValue: false,
+  });
+  if (p.isCancel(customizeModels)) return cancelAndExit();
+
+  if (customizeModels) {
+    p.log.info(
+      'These names must match `model_name` entries in apps/cli/infra/litellm-config.yaml.\n' +
+        'Edit the YAML to add new aliases (e.g. mapping a tier to a different DeepSeek model).',
+    );
+
+    const small = await p.text({
+      message: 'Small model alias',
+      initialValue: 'shannon-small',
+      validate: required('Small model alias is required'),
+    });
+    if (p.isCancel(small)) return cancelAndExit();
+
+    const medium = await p.text({
+      message: 'Medium model alias',
+      initialValue: 'shannon-medium',
+      validate: required('Medium model alias is required'),
+    });
+    if (p.isCancel(medium)) return cancelAndExit();
+
+    const large = await p.text({
+      message: 'Large model alias',
+      initialValue: 'shannon-large',
+      validate: required('Large model alias is required'),
+    });
+    if (p.isCancel(large)) return cancelAndExit();
+
+    config.models = { small, medium, large };
+  }
+
+  return config;
 }
 
 // === Provider Setup Flows ===

--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -349,6 +349,10 @@ async function setupVertex(): Promise<ShannonConfig> {
 // === Helpers ===
 
 async function maybePromptAdaptiveThinking(config: ShannonConfig): Promise<void> {
+  // Adaptive thinking only applies to Claude — skip for providers that route to
+  // non-Anthropic models (DeepSeek's `shannon-*` aliases can't match opus-4-[67]).
+  if (config.deepseek) return;
+
   const m = config.models;
   const hasOpus47 = !m || [m.small, m.medium, m.large].some((v) => v && /opus-4-[67]/.test(v));
   if (!hasOpus47) return;

--- a/apps/cli/src/config/resolver.ts
+++ b/apps/cli/src/config/resolver.ts
@@ -46,6 +46,10 @@ const CONFIG_MAP: readonly ConfigMapping[] = [
   { env: 'ANTHROPIC_BASE_URL', toml: 'custom_base_url.base_url', type: 'string' },
   { env: 'ANTHROPIC_AUTH_TOKEN', toml: 'custom_base_url.auth_token', type: 'string' },
 
+  // DeepSeek (via embedded LiteLLM proxy)
+  { env: 'DEEPSEEK_API_KEY', toml: 'deepseek.api_key', type: 'string' },
+  { env: 'LITELLM_MASTER_KEY', toml: 'deepseek.master_key', type: 'string' },
+
   // Model tiers
   { env: 'ANTHROPIC_SMALL_MODEL', toml: 'models.small', type: 'string' },
   { env: 'ANTHROPIC_MEDIUM_MODEL', toml: 'models.medium', type: 'string' },
@@ -145,6 +149,15 @@ function validateProviderFields(config: TOMLConfig, provider: string, errors: st
       break;
     }
 
+    case 'deepseek': {
+      const required = ['api_key', 'master_key'];
+      const missing = required.filter((k) => !keys.includes(k));
+      if (missing.length > 0) {
+        errors.push(`[deepseek] missing required keys: ${missing.join(', ')}`);
+      }
+      break;
+    }
+
     case 'bedrock': {
       const required = ['use', 'region', 'token'];
       const missing = required.filter((k) => !keys.includes(k));
@@ -227,7 +240,7 @@ function validateConfig(config: TOMLConfig): string[] {
   }
 
   // 4. Only one provider section allowed (ignore empty sections)
-  const PROVIDER_SECTIONS = ['anthropic', 'custom_base_url', 'bedrock', 'vertex'] as const;
+  const PROVIDER_SECTIONS = ['anthropic', 'custom_base_url', 'bedrock', 'vertex', 'deepseek'] as const;
   const present = PROVIDER_SECTIONS.filter((s) => {
     const section = config[s];
     return section && typeof section === 'object' && Object.keys(section).length > 0;

--- a/apps/cli/src/config/writer.ts
+++ b/apps/cli/src/config/writer.ts
@@ -13,6 +13,7 @@ export interface ShannonConfig {
   custom_base_url?: { base_url?: string; auth_token?: string };
   bedrock?: { use?: boolean; region?: string; token?: string };
   vertex?: { use?: boolean; region?: string; project_id?: string; key_path?: string };
+  deepseek?: { api_key?: string; master_key?: string };
   models?: { small?: string; medium?: string; large?: string };
 }
 

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -11,6 +11,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
+import { isDeepseekMode } from './env.js';
 import { getMode } from './mode.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -70,27 +71,70 @@ export function isTemporalReady(): boolean {
 }
 
 /**
- * Ensure Temporal is running via compose.
+ * Check if the LiteLLM proxy (DeepSeek mode only) is up and responding to
+ * its built-in liveness probe.
+ */
+export function isLitellmReady(): boolean {
+  return runQuiet('docker', [
+    'exec',
+    'shannon-litellm',
+    'python',
+    '-c',
+    "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')",
+  ]);
+}
+
+/**
+ * Compose flags including the `deepseek` profile when DeepSeek mode is active.
+ * Activating the profile is what makes the litellm service start.
+ */
+function composeFlags(): string[] {
+  const flags = ['-f', getComposeFile()];
+  if (isDeepseekMode()) {
+    flags.push('--profile', 'deepseek');
+  }
+  return flags;
+}
+
+/**
+ * Ensure Temporal (and, in DeepSeek mode, LiteLLM) are running via compose.
  */
 export async function ensureInfra(): Promise<void> {
-  if (isTemporalReady()) {
+  const needsLitellm = isDeepseekMode();
+  if (isTemporalReady() && (!needsLitellm || isLitellmReady())) {
     return;
   }
 
-  const composeFile = getComposeFile();
   console.log('Starting Shannon infrastructure...');
-  execFileSync('docker', ['compose', '-f', composeFile, 'up', '-d'], { stdio: 'inherit' });
+  execFileSync('docker', ['compose', ...composeFlags(), 'up', '-d'], { stdio: 'inherit' });
 
   console.log('Waiting for Temporal to be ready...');
   for (let i = 0; i < 30; i++) {
     if (isTemporalReady()) {
       console.log('Temporal is ready!');
-      return;
+      break;
+    }
+    if (i === 29) {
+      console.error('Timeout waiting for Temporal');
+      process.exit(1);
     }
     await sleep(2000);
   }
-  console.error('Timeout waiting for Temporal');
-  process.exit(1);
+
+  if (needsLitellm) {
+    console.log('Waiting for LiteLLM proxy to be ready...');
+    for (let i = 0; i < 30; i++) {
+      if (isLitellmReady()) {
+        console.log('LiteLLM proxy is ready!');
+        return;
+      }
+      if (i === 29) {
+        console.error('Timeout waiting for LiteLLM proxy. Run: docker logs shannon-litellm');
+        process.exit(1);
+      }
+      await sleep(2000);
+    }
+  }
 }
 
 /**

--- a/apps/cli/src/env.ts
+++ b/apps/cli/src/env.ts
@@ -30,16 +30,42 @@ const FORWARD_VARS = [
 ] as const;
 
 /**
+ * DeepSeek mode is active when DEEPSEEK_API_KEY is configured. The LiteLLM
+ * proxy container reads DEEPSEEK_API_KEY and LITELLM_MASTER_KEY from the
+ * compose-up environment, so they are NOT forwarded to worker containers.
+ */
+export function isDeepseekMode(): boolean {
+  return !!process.env.DEEPSEEK_API_KEY;
+}
+
+/**
  * Load credentials into process.env.
  * Local mode: loads ./.env via dotenv.
  * NPX mode: fills gaps from ~/.shannon/config.toml.
  * Exported env vars always take precedence in both modes.
+ *
+ * When DeepSeek mode is detected, also configure the worker to route through
+ * the embedded LiteLLM proxy on shannon-net by setting ANTHROPIC_BASE_URL,
+ * ANTHROPIC_AUTH_TOKEN, and the three model tier env vars. These derived
+ * values are skipped if already explicitly set by the user.
  */
 export function loadEnv(): void {
   if (getMode() === 'local') {
     dotenv.config({ path: '.env', quiet: true });
   } else {
     resolveConfig();
+  }
+
+  if (isDeepseekMode()) {
+    if (!process.env.ANTHROPIC_BASE_URL) {
+      process.env.ANTHROPIC_BASE_URL = 'http://shannon-litellm:4000';
+    }
+    if (!process.env.ANTHROPIC_AUTH_TOKEN && process.env.LITELLM_MASTER_KEY) {
+      process.env.ANTHROPIC_AUTH_TOKEN = process.env.LITELLM_MASTER_KEY;
+    }
+    if (!process.env.ANTHROPIC_SMALL_MODEL) process.env.ANTHROPIC_SMALL_MODEL = 'shannon-small';
+    if (!process.env.ANTHROPIC_MEDIUM_MODEL) process.env.ANTHROPIC_MEDIUM_MODEL = 'shannon-medium';
+    if (!process.env.ANTHROPIC_LARGE_MODEL) process.env.ANTHROPIC_LARGE_MODEL = 'shannon-large';
   }
 }
 
@@ -62,7 +88,7 @@ export function buildEnvFlags(): string[] {
 interface CredentialValidation {
   valid: boolean;
   error?: string;
-  mode: 'api-key' | 'oauth' | 'custom-base-url' | 'bedrock' | 'vertex';
+  mode: 'api-key' | 'oauth' | 'custom-base-url' | 'bedrock' | 'vertex' | 'deepseek';
 }
 
 /** Check if a custom Anthropic-compatible base URL is configured. */
@@ -73,9 +99,10 @@ function isCustomBaseUrlConfigured(): boolean {
 /** Detect which providers are configured via environment variables. */
 function detectProviders(): string[] {
   const providers: string[] = [];
+  if (isDeepseekMode()) providers.push('DeepSeek');
   if (process.env.ANTHROPIC_API_KEY) providers.push('Anthropic API key');
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) providers.push('Anthropic OAuth');
-  if (isCustomBaseUrlConfigured()) providers.push('Custom Base URL');
+  if (!isDeepseekMode() && isCustomBaseUrlConfigured()) providers.push('Custom Base URL');
   if (process.env.CLAUDE_CODE_USE_BEDROCK === '1') providers.push('AWS Bedrock');
   if (process.env.CLAUDE_CODE_USE_VERTEX === '1') providers.push('Google Vertex');
   return providers;
@@ -95,6 +122,16 @@ export function validateCredentials(): CredentialValidation {
     };
   }
 
+  if (isDeepseekMode()) {
+    if (!process.env.LITELLM_MASTER_KEY) {
+      return {
+        valid: false,
+        mode: 'deepseek',
+        error: 'DeepSeek mode requires LITELLM_MASTER_KEY. Run `npx @keygraph/shannon setup` to reconfigure.',
+      };
+    }
+    return { valid: true, mode: 'deepseek' };
+  }
   if (process.env.ANTHROPIC_API_KEY) {
     return { valid: true, mode: 'api-key' };
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     container_name: shannon-litellm
     profiles: ["deepseek"]
     command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    ports:
+      - "127.0.0.1:4000:4000"   # localhost-only — for debugging via curl
     environment:
       DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,26 @@ services:
       retries: 10
       start_period: 30s
 
+  # LiteLLM proxy — Anthropic-compatible front-end that routes Shannon's
+  # Claude Agent SDK requests to DeepSeek. Only started when the `deepseek`
+  # compose profile is enabled (the CLI passes --profile deepseek when DeepSeek
+  # mode is active).
+  litellm:
+    image: ghcr.io/berriai/litellm:main-stable
+    container_name: shannon-litellm
+    profiles: ["deepseek"]
+    command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    environment:
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY}
+    volumes:
+      - ./apps/cli/infra/litellm-config.yaml:/etc/litellm/config.yaml:ro
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
 volumes:
   temporal-data:


### PR DESCRIPTION
## Summary

Add a `DeepSeek` option to the setup wizard backed by an embedded [LiteLLM](https://github.com/BerriAI/litellm) proxy container on `shannon-net`. The proxy accepts Anthropic Messages API requests and translates them to DeepSeek's OpenAI-compatible chat completions API.

When `DEEPSEEK_API_KEY` is set the CLI:
- Starts `shannon-litellm` automatically via a new `deepseek` compose profile.
- Derives `ANTHROPIC_BASE_URL=http://shannon-litellm:4000`, `ANTHROPIC_AUTH_TOKEN=$LITELLM_MASTER_KEY`, and `ANTHROPIC_*_MODEL=shannon-*` so the Claude Agent SDK transparently talks to the proxy.
- Routes the three tiers to `deepseek/deepseek-chat` (small/medium) and `deepseek/deepseek-reasoner` (large) via `apps/cli/infra/litellm-config.yaml`.

**No changes to the worker or the Claude Agent SDK integration** — this rides entirely on the existing `Custom Base URL` plumbing.

Files touched:
- `apps/cli/infra/litellm-config.yaml` (new) — LiteLLM model mapping.
- `docker-compose.yml`, `apps/cli/infra/compose.yml` — new `litellm` service (gated by `profiles: ["deepseek"]`).
- `apps/cli/src/env.ts` — `isDeepseekMode()`, auto-set proxy env vars, validate `LITELLM_MASTER_KEY`.
- `apps/cli/src/docker.ts` — pass `--profile deepseek` to `compose up`, wait for proxy health.
- `apps/cli/src/commands/setup.ts` — new `DeepSeek` wizard option.
- `apps/cli/src/config/{writer,resolver}.ts` — `[deepseek]` section in `~/.shannon/config.toml`.
- `README.md`, `CLAUDE.md`, `.env.example` — docs.

## Review & Testing Checklist for Human

- [ ] **Run an end-to-end pentest with DeepSeek.** `npx @keygraph/shannon setup` → select `DeepSeek` → paste API key → run a small scan against a target you own. Confirm the proxy starts, the worker hits it (`docker logs shannon-litellm`), and the pipeline completes with at least one finding.
- [ ] **Verify Claude paths still work.** Run `npx @keygraph/shannon setup` and pick `Claude Direct` / `Custom Base URL` / `Bedrock` / `Vertex` — confirm none of them spin up the LiteLLM container (it should only start when `DEEPSEEK_API_KEY` is set).
- [ ] **Validate the model aliases.** Inspect `apps/cli/infra/litellm-config.yaml` and decide whether you want a different DeepSeek model for any tier (e.g. `deepseek-reasoner` for everything).
- [ ] **Sanity-check the proxy auth.** The wizard generates a random `LITELLM_MASTER_KEY`; confirm an unauthenticated curl to the proxy is rejected: `curl -v http://localhost:4000/v1/messages -H "x-api-key: wrong"` (it should 401).
- [ ] **CI must pass.** Particularly the existing `biome` and `tsc --noEmit` jobs (this PR touches neither generated files nor worker code, so they should pass without additional fixes).

Suggested local test plan:
```bash
export DEEPSEEK_API_KEY=sk-...
export LITELLM_MASTER_KEY=sk-shannon-$(openssl rand -hex 16)
pnpm install && pnpm build
./shannon start -u https://your-target -r /path/to/repo --pipeline-testing
# In another shell, watch the proxy:
docker logs -f shannon-litellm
```

### Notes

- **Explicitly flagged as experimental and unsupported.** The README, `.env.example`, and a `> [!WARNING]` callout all state that Shannon's prompts and evals are tuned for Claude — DeepSeek tool-calling and reasoning behave differently, and pentest quality may degrade. This also runs against the [Sunsetting router mode](https://github.com/KeygraphHQ/shannon/discussions/301) direction, so we may want to reject this entirely.
- The `deepseek` compose profile means the LiteLLM container only starts when DeepSeek mode is active; all other providers behave identically to before.
- Adaptive thinking is naturally a no-op for DeepSeek: `supportsAdaptiveThinking()` only matches `opus-4-[67]`, and the model aliases here don't match.
- MCP servers (e.g. `playwright-cli`) are unaffected — they run as local subprocesses inside the worker, not through the model API.
- Prompt caching headers are silently ignored by LiteLLM; this is expected and noted in the README.
- I could not push directly to `KeygraphHQ/shannon`, so the branch lives on a fork at https://github.com/badreddinekarama/shannon/tree/devin/1778779770-deepseek-via-litellm-proxy.
