### PR TITLE
fix(docker): increase Temporal startup timeout for Windows/WSL2

### DIFF
--- a/apps/cli/infra/compose.yml
+++ b/apps/cli/infra/compose.yml
@@ -17,7 +17,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 60s
 
 volumes:
   temporal-data:

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -70,7 +70,25 @@ export function isTemporalReady(): boolean {
 }
 
 /**
+ * Check if the Temporal container reports healthy via Docker's own healthcheck.
+ * This avoids racing the compose healthcheck with our own poll loop.
+ */
+function isContainerHealthy(container: string): boolean {
+  const status = runOutput('docker', [
+    'inspect',
+    '--format',
+    '{{.State.Health.Status}}',
+    container,
+  ]);
+  return status === 'healthy';
+}
+
+/**
  * Ensure Temporal is running via compose.
+ *
+ * The timeout is configurable via SHANNON_TEMPORAL_TIMEOUT_MS (default: 120000).
+ * On Windows/WSL2, Temporal's SQLite journal writes can take 20-40s longer
+ * due to NTFS-backed Docker volumes, so the default is generous.
  */
 export async function ensureInfra(): Promise<void> {
   if (isTemporalReady()) {
@@ -81,15 +99,23 @@ export async function ensureInfra(): Promise<void> {
   console.log('Starting Shannon infrastructure...');
   execFileSync('docker', ['compose', '-f', composeFile, 'up', '-d'], { stdio: 'inherit' });
 
+  const timeoutMs = Number(process.env.SHANNON_TEMPORAL_TIMEOUT_MS) || 120_000;
+  const pollIntervalMs = 3_000;
+  const deadline = Date.now() + timeoutMs;
+
   console.log('Waiting for Temporal to be ready...');
-  for (let i = 0; i < 30; i++) {
-    if (isTemporalReady()) {
+  while (Date.now() < deadline) {
+    // Prefer Docker's own healthcheck verdict when available
+    if (isContainerHealthy('shannon-temporal') || isTemporalReady()) {
       console.log('Temporal is ready!');
       return;
     }
-    await sleep(2000);
+    await sleep(pollIntervalMs);
   }
-  console.error('Timeout waiting for Temporal');
+  console.error(
+    `Timeout waiting for Temporal after ${timeoutMs / 1000}s. ` +
+      'If you are on Windows/WSL2, try increasing SHANNON_TEMPORAL_TIMEOUT_MS.',
+  );
   process.exit(1);
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 60s
 
 volumes:
   temporal-data:


### PR DESCRIPTION
﻿## Summary

Fixes #331

## Root cause

The fixed 60s poll budget (30 iterations x 2s) is exhausted on WSL2 where NTFS-backed Docker volumes add 20-40s to Temporal's SQLite journal init. The CLI poll loop also races Docker's own healthcheck rather than coordinating with it.

## Changes

- Replace fixed-iteration loop with deadline-based timeout (default 120s)
- Add isContainerHealthy() that checks Docker's healthcheck status
- Accept SHANNON_TEMPORAL_TIMEOUT_MS env var for custom timeout
- Increase poll interval from 2s to 3s
- Bump start_period in both compose files from 30s to 60s
- Actionable error message on timeout

## Test plan

- Verify on Linux (fast path)
- Verify on Windows/WSL2 (slow path: 40-90s startup)
- Verify SHANNON_TEMPORAL_TIMEOUT_MS=30000 causes timeout on slow hosts
