### PR TITLE
docs: distinguish Keygraph (company) from the Keygraph platform (product) across README, docs, and llms files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Shannon is an autonomous AI pentester developed by [Keygraph](https://keygraph.i
 
 Shannon analyzes your web application's source code to identify potential attack vectors, then uses browser automation and command-line tools to execute real exploits against the running application and its APIs. Only vulnerabilities with a working proof-of-concept are included in the final report.
 
-Shannon is the agent. This repository is Shannon Open Source, the standalone pentester you run yourself. The same Shannon also powers [Keygraph](https://keygraph.io), Keygraph's commercial pentesting platform. See [Editions](#editions) for how the two compare.
+Shannon is the agent. This repository is Shannon Open Source, the standalone pentester you run yourself. The same Shannon also powers the [Keygraph platform](https://keygraph.io), Keygraph's commercial pentesting product. See [Editions](#editions) for how the two compare.
 
 ### Why Shannon Exists
 
@@ -103,11 +103,11 @@ For source builds, authenticated scans, provider-specific setup, and platform no
 
 ## Editions
 
-Shannon ships in two ways: **Shannon Open Source**, the pentester you run yourself, and **Keygraph**, the commercial pentesting platform that runs Shannon continuously and closes the full AppSec lifecycle around it.
+Shannon ships in two ways: **Shannon Open Source**, the pentester you run yourself, and the **Keygraph platform**, the commercial pentesting product that runs Shannon continuously and closes the full AppSec lifecycle around it.
 
 **Shannon Open Source** (this repository) is the standalone pentester: a CLI agent for white-box, proof-by-exploitation testing of web applications and APIs you own or are authorized to test. It reads your source, plans attacks, executes real exploits, and reports only what it can prove. It runs on demand and is complete in that lane. You point it at a target, it pentests, it reports.
 
-**Keygraph** is the enterprise-ready, continuous pentesting platform powered by Shannon. In Keygraph, an enhanced build of Shannon runs continuously in a hardened, orchestrated environment fed by Keygraph's full code-analysis stack. Around that engine, the platform closes the entire vulnerability lifecycle, from analysis to a verified fix:
+The **Keygraph platform** is the enterprise-ready, continuous pentesting product powered by Shannon. In the Keygraph platform, an enhanced build of Shannon runs continuously in a hardened, orchestrated environment fed by Keygraph's full code-analysis stack. Around that engine, the platform closes the entire vulnerability lifecycle, from analysis to a verified fix:
 
 - **Analyze**: Code Property Graph SAST, SCA with reachability, secrets, IaC, and container scanning. First-class detection in their own right, and context that sharpens Shannon's attacks.
 - **Prove**: autonomous black-box and source-aware white-box pentests turn candidate findings into proven, exploited vulnerabilities rather than speculative alerts.
@@ -115,9 +115,9 @@ Shannon ships in two ways: **Shannon Open Source**, the pentester you run yourse
 - **Remediate and verify**: patches written automatically and re-tested against the patched code before delivery, landing in your existing review workflow rather than auto-applied.
 - **Deploy**: self-hosted and air-gapped environments, strict bring-your-own-key model access, and customer-controlled LLM gateway patterns, so source, results, and model traffic stay inside your perimeter.
 
-Shannon is the proof engine at the center of Keygraph. Shannon Open Source gives you that engine to run yourself. Keygraph surrounds Shannon with continuous analysis, finding management, remediation, verification, and enterprise deployment.
+Shannon is the proof engine at the center of the Keygraph platform. Shannon Open Source gives you that engine to run yourself. The Keygraph platform surrounds Shannon with continuous analysis, finding management, remediation, verification, and enterprise deployment.
 
-| AppSec lifecycle stage | Shannon Open Source | Keygraph |
+| AppSec lifecycle stage | Shannon Open Source | Keygraph platform |
 | --- | --- | --- |
 | Analyze | Basic LLM pass-through of source to plan attacks | Actual code-base parsing, plus Code Property Graph, SAST, SCA with reachability, secrets, IaC, and containers |
 | Pentest and prove | White-box only, proof by exploitation | Enhanced white-box, plus black-box and grey-box modes, run continuously |
@@ -126,7 +126,7 @@ Shannon is the proof engine at the center of Keygraph. Shannon Open Source gives
 | Deploy and operate | Local CLI and Docker worker | Self-hosted, air-gapped, BYOK, continuous, enterprise integrations |
 | License and support | AGPL-3.0, community | Commercial, supported |
 
-Learn more on the [Keygraph website](https://keygraph.io), read the [Keygraph technical overview](docs/keygraph-platform.md), start a free trial or book a [demo](https://cal.com/team/keygraph/shannon-pro), or contact [shannon@keygraph.io](mailto:shannon@keygraph.io).
+Learn more on the [Keygraph website](https://keygraph.io), read the [Keygraph platform technical overview](docs/keygraph-platform.md), start a free trial or book a [demo](https://cal.com/team/keygraph/shannon-pro), or contact [shannon@keygraph.io](mailto:shannon@keygraph.io).
 
 ## Architecture
 
@@ -191,7 +191,7 @@ Use these guides for operational detail:
 | [Workspaces and resuming](docs/workspaces.md) | Naming workspaces, resuming interrupted scans, and workspace storage. |
 | [Safety and limitations](docs/safety.md) | Authorized-use requirements, non-production guidance, mutative effects, cost, and model caveats. |
 | [Coverage and roadmap](docs/coverage-roadmap.md) | Current vulnerability coverage and planned work. |
-| [Keygraph](docs/keygraph-platform.md) | The continuous, agentic pentesting platform: code analysis, black-box and white-box testing, finding management, remediation, verification, and enterprise deployment. |
+| [Keygraph platform](docs/keygraph-platform.md) | The continuous, agentic pentesting platform: code analysis, black-box and white-box testing, finding management, remediation, verification, and enterprise deployment. |
 
 ## Safety, Scope, and Limitations
 
@@ -201,7 +201,7 @@ You are responsible for using Shannon legally and ethically. Do not point Shanno
 
 Important limitations:
 
-- Shannon Open Source focuses on actively exploitable issues such as Injection, XSS, SSRF, Broken Authentication, and Broken Authorization. Broader static-analysis coverage, including vulnerable dependencies and insecure configurations, is delivered through Keygraph.
+- Shannon Open Source focuses on actively exploitable issues such as Injection, XSS, SSRF, Broken Authentication, and Broken Authorization. Broader static-analysis coverage, including vulnerable dependencies and insecure configurations, is delivered through the Keygraph platform.
 - Findings still require human review. LLM-generated reports can contain weakly supported or incorrect details.
 - Shannon is officially supported with Claude models. Smaller, alternative, or proxied non-Claude models may be incomplete or unstable.
 - A full run can take roughly 1 to 1.5 hours and may incur LLM API costs depending on model pricing and application complexity.
@@ -213,13 +213,13 @@ Read the full [Safety and limitations](docs/safety.md) guide before running Shan
 
 Shannon Open Source is licensed under the [GNU Affero General Public License v3.0](LICENSE).
 
-Commercial and enterprise licensing is available for organizations that need different license terms, commercial support, private redistribution, managed-service use, or broader deployment options, including Keygraph.
+Commercial and enterprise licensing is available for organizations that need different license terms, commercial support, private redistribution, managed-service use, or broader deployment options, including the Keygraph platform.
 
 For commercial licensing, contact [shannon@keygraph.io](mailto:shannon@keygraph.io).
 
 ## About Keygraph
 
-**Keygraph** is the company behind Shannon. It also builds **Keygraph**, the commercial agentic pentesting platform that closes the full AppSec lifecycle and runs an enhanced build of Shannon as its pentesting engine.
+**Keygraph** is the company behind Shannon. It also builds the **Keygraph platform**, the commercial agentic pentesting product that closes the full AppSec lifecycle and runs an enhanced build of Shannon as its pentesting engine.
 
 ## Community and Support
 

--- a/docs/coverage-roadmap.md
+++ b/docs/coverage-roadmap.md
@@ -20,4 +20,4 @@ This reduces speculative noise, but it also means Shannon does not aim to report
 
 Planned coverage areas should continue to live in the repository's canonical roadmap document if one exists. The README should link to that document rather than carrying detailed roadmap history inline.
 
-For organizations that need broader static and organizational coverage now, see [Keygraph](keygraph-platform.md).
+For organizations that need broader static and organizational coverage now, see [the Keygraph platform](keygraph-platform.md).

--- a/docs/keygraph-platform.md
+++ b/docs/keygraph-platform.md
@@ -1,12 +1,12 @@
-# Keygraph
+# Keygraph Platform
 
-Keygraph is the commercial continuous pentesting and AppSec platform for teams running security across many repositories, services, and environments. While Shannon is a local white-box pentesting CLI, Keygraph is a full platform: it combines parsed-code SAST, source-to-sink analysis, black-box and white-box agentic pentesting, verified remediation, CI/CD gating, SLA tracking, and reporting for security and compliance teams.
+The Keygraph platform is Keygraph's commercial continuous pentesting and AppSec platform for teams running security across many repositories, services, and environments. While Shannon is a local white-box pentesting CLI, the Keygraph platform is a complete AppSec system: it combines parsed-code SAST, source-to-sink analysis, black-box and white-box agentic pentesting, verified remediation, CI/CD gating, SLA tracking, and reporting for security and compliance teams.
 
-This repository contains Shannon, the AGPL-3.0 open-source CLI for strictly white-box pentesting. Keygraph supports both white-box and black-box agentic pentesting and adds static analysis, finding management, remediation workflows, reporting, and enterprise deployment options.
+This repository contains Shannon, the AGPL-3.0 open-source CLI for strictly white-box pentesting. The Keygraph platform supports both white-box and black-box agentic pentesting and adds static analysis, finding management, remediation workflows, reporting, and enterprise deployment options.
 
-## Who Should Consider Keygraph
+## Who Should Consider the Keygraph Platform
 
-Keygraph is intended for organizations that need:
+The Keygraph platform is intended for organizations that need:
 
 - Continuous AppSec coverage across many repositories and services
 - White-box pentesting when source code is available
@@ -21,7 +21,7 @@ Keygraph is intended for organizations that need:
 
 ## Full Vulnerability Lifecycle
 
-Keygraph is designed to cover the full vulnerability lifecycle, not only discovery:
+The Keygraph platform is designed to cover the full vulnerability lifecycle, not only discovery:
 
 1. **Find** exploitable issues with white-box pentesting, black-box pentesting, SAST, SCA, secrets, IaC, container, and business logic testing.
 2. **Normalize** results into canonical findings so duplicate scanner outputs become one tracked vulnerability per repository.
@@ -36,7 +36,7 @@ Keygraph is designed to cover the full vulnerability lifecycle, not only discove
 
 Shannon is strictly white-box: it requires access to the target application's source code and repository layout.
 
-Keygraph supports two pentesting modes:
+The Keygraph platform supports two pentesting modes:
 
 - **White-box agentic pentesting**: Agents use source-code context to understand architecture, identify realistic attack paths, and validate exploitability against the running application.
 - **Black-box agentic pentesting**: Agents test deployed applications and APIs without source-code access, useful for third-party surfaces, production-like external validation, or environments where source access is unavailable.
@@ -45,7 +45,7 @@ Both modes follow the same core principle: do not report what might be vulnerabl
 
 ## AppSec Coverage
 
-Keygraph combines agentic pentesting with broader AppSec coverage:
+The Keygraph platform combines agentic pentesting with broader AppSec coverage:
 
 - **Agentic SAST**: Code Property Graph analysis with LLM reasoning for data flow, context, and sanitization decisions.
 - **SCA with reachability**: Dependency vulnerability analysis that prioritizes issues reachable from application entry points.
@@ -62,7 +62,7 @@ The result is a finding with proof of exploitability, source context when availa
 
 ## Enterprise Deployment
 
-Keygraph supports enterprise deployment patterns for teams with strict data, model, and network requirements:
+The Keygraph platform supports enterprise deployment patterns for teams with strict data, model, and network requirements:
 
 - **Self-hosted deployments** inside the customer's cloud or infrastructure
 - **Air-gapped deployments** for isolated environments
@@ -75,7 +75,7 @@ Deployments can be designed so source code, scan results, prompts, completions, 
 
 ## Capability Comparison
 
-| Need | Shannon | Keygraph |
+| Need | Shannon | Keygraph platform |
 | --- | --- | --- |
 | Licensing | AGPL-3.0 | Commercial |
 | White-box pentesting | Yes; source code required | Yes; source-aware testing with platform workflows |

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -43,7 +43,7 @@ Shannon currently targets exploitable vulnerabilities in these classes:
 
 Shannon's proof-by-exploitation model means it does not report issues it cannot actively exploit, such as many vulnerable dependency, insecure configuration, or broad policy findings.
 
-For broader coverage, Keygraph adds black-box and white-box agentic pentesting, graph-based static analysis, SCA reachability, secrets detection, business logic testing, remediation workflows, SLA tracking, and reporting dashboards.
+For broader coverage, the Keygraph platform adds black-box and white-box agentic pentesting, graph-based static analysis, SCA reachability, secrets detection, business logic testing, remediation workflows, SLA tracking, and reporting dashboards.
 
 ## Cost and Performance
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -54,7 +54,7 @@ Shannon is an autonomous AI pentester developed by [Keygraph](https://keygraph.i
 
 Shannon analyzes your web application's source code to identify potential attack vectors, then uses browser automation and command-line tools to execute real exploits against the running application and its APIs. Only vulnerabilities with a working proof-of-concept are included in the final report.
 
-Shannon is the agent. This repository is Shannon Open Source, the standalone pentester you run yourself. The same Shannon also powers [Keygraph](https://keygraph.io), Keygraph's commercial pentesting platform. See [Editions](#editions) for how the two compare.
+Shannon is the agent. This repository is Shannon Open Source, the standalone pentester you run yourself. The same Shannon also powers the [Keygraph platform](https://keygraph.io), Keygraph's commercial pentesting product. See [Editions](#editions) for how the two compare.
 
 ### Why Shannon Exists
 
@@ -112,11 +112,11 @@ For source builds, authenticated scans, provider-specific setup, and platform no
 
 ## Editions
 
-Shannon ships in two ways: **Shannon Open Source**, the pentester you run yourself, and **Keygraph**, the commercial pentesting platform that runs Shannon continuously and closes the full AppSec lifecycle around it.
+Shannon ships in two ways: **Shannon Open Source**, the pentester you run yourself, and the **Keygraph platform**, the commercial pentesting product that runs Shannon continuously and closes the full AppSec lifecycle around it.
 
 **Shannon Open Source** (this repository) is the standalone pentester: a CLI agent for white-box, proof-by-exploitation testing of web applications and APIs you own or are authorized to test. It reads your source, plans attacks, executes real exploits, and reports only what it can prove. It runs on demand and is complete in that lane. You point it at a target, it pentests, it reports.
 
-**Keygraph** is the enterprise-ready, continuous pentesting platform powered by Shannon. In Keygraph, an enhanced build of Shannon runs continuously in a hardened, orchestrated environment fed by Keygraph's full code-analysis stack. Around that engine, the platform closes the entire vulnerability lifecycle, from analysis to a verified fix:
+The **Keygraph platform** is the enterprise-ready, continuous pentesting product powered by Shannon. In the Keygraph platform, an enhanced build of Shannon runs continuously in a hardened, orchestrated environment fed by Keygraph's full code-analysis stack. Around that engine, the platform closes the entire vulnerability lifecycle, from analysis to a verified fix:
 
 - **Analyze**: Code Property Graph SAST, SCA with reachability, secrets, IaC, and container scanning. First-class detection in their own right, and context that sharpens Shannon's attacks.
 - **Prove**: autonomous black-box and source-aware white-box pentests turn candidate findings into proven, exploited vulnerabilities rather than speculative alerts.
@@ -124,9 +124,9 @@ Shannon ships in two ways: **Shannon Open Source**, the pentester you run yourse
 - **Remediate and verify**: patches written automatically and re-tested against the patched code before delivery, landing in your existing review workflow rather than auto-applied.
 - **Deploy**: self-hosted and air-gapped environments, strict bring-your-own-key model access, and customer-controlled LLM gateway patterns, so source, results, and model traffic stay inside your perimeter.
 
-Shannon is the proof engine at the center of Keygraph. Shannon Open Source gives you that engine to run yourself. Keygraph surrounds Shannon with continuous analysis, finding management, remediation, verification, and enterprise deployment.
+Shannon is the proof engine at the center of the Keygraph platform. Shannon Open Source gives you that engine to run yourself. The Keygraph platform surrounds Shannon with continuous analysis, finding management, remediation, verification, and enterprise deployment.
 
-| AppSec lifecycle stage | Shannon Open Source | Keygraph |
+| AppSec lifecycle stage | Shannon Open Source | Keygraph platform |
 | --- | --- | --- |
 | Analyze | Basic LLM pass-through of source to plan attacks | Actual code-base parsing, plus Code Property Graph, SAST, SCA with reachability, secrets, IaC, and containers |
 | Pentest and prove | White-box only, proof by exploitation | Enhanced white-box, plus black-box and grey-box modes, run continuously |
@@ -135,7 +135,7 @@ Shannon is the proof engine at the center of Keygraph. Shannon Open Source gives
 | Deploy and operate | Local CLI and Docker worker | Self-hosted, air-gapped, BYOK, continuous, enterprise integrations |
 | License and support | AGPL-3.0, community | Commercial, supported |
 
-Learn more on the [Keygraph website](https://keygraph.io), read the [Keygraph technical overview](docs/keygraph-platform.md), start a free trial or book a [demo](https://cal.com/team/keygraph/shannon-pro), or contact [shannon@keygraph.io](mailto:shannon@keygraph.io).
+Learn more on the [Keygraph website](https://keygraph.io), read the [Keygraph platform technical overview](docs/keygraph-platform.md), start a free trial or book a [demo](https://cal.com/team/keygraph/shannon-pro), or contact [shannon@keygraph.io](mailto:shannon@keygraph.io).
 
 ## Architecture
 
@@ -200,7 +200,7 @@ Use these guides for operational detail:
 | [Workspaces and resuming](docs/workspaces.md) | Naming workspaces, resuming interrupted scans, and workspace storage. |
 | [Safety and limitations](docs/safety.md) | Authorized-use requirements, non-production guidance, mutative effects, cost, and model caveats. |
 | [Coverage and roadmap](docs/coverage-roadmap.md) | Current vulnerability coverage and planned work. |
-| [Keygraph](docs/keygraph-platform.md) | The continuous, agentic pentesting platform: code analysis, black-box and white-box testing, finding management, remediation, verification, and enterprise deployment. |
+| [Keygraph platform](docs/keygraph-platform.md) | The continuous, agentic pentesting platform: code analysis, black-box and white-box testing, finding management, remediation, verification, and enterprise deployment. |
 
 ## Safety, Scope, and Limitations
 
@@ -210,7 +210,7 @@ You are responsible for using Shannon legally and ethically. Do not point Shanno
 
 Important limitations:
 
-- Shannon Open Source focuses on actively exploitable issues such as Injection, XSS, SSRF, Broken Authentication, and Broken Authorization. Broader static-analysis coverage, including vulnerable dependencies and insecure configurations, is delivered through Keygraph.
+- Shannon Open Source focuses on actively exploitable issues such as Injection, XSS, SSRF, Broken Authentication, and Broken Authorization. Broader static-analysis coverage, including vulnerable dependencies and insecure configurations, is delivered through the Keygraph platform.
 - Findings still require human review. LLM-generated reports can contain weakly supported or incorrect details.
 - Shannon is officially supported with Claude models. Smaller, alternative, or proxied non-Claude models may be incomplete or unstable.
 - A full run can take roughly 1 to 1.5 hours and may incur LLM API costs depending on model pricing and application complexity.
@@ -222,13 +222,13 @@ Read the full [Safety and limitations](docs/safety.md) guide before running Shan
 
 Shannon Open Source is licensed under the [GNU Affero General Public License v3.0](LICENSE).
 
-Commercial and enterprise licensing is available for organizations that need different license terms, commercial support, private redistribution, managed-service use, or broader deployment options, including Keygraph.
+Commercial and enterprise licensing is available for organizations that need different license terms, commercial support, private redistribution, managed-service use, or broader deployment options, including the Keygraph platform.
 
 For commercial licensing, contact [shannon@keygraph.io](mailto:shannon@keygraph.io).
 
 ## About Keygraph
 
-**Keygraph** is the company behind Shannon. It also builds **Keygraph**, the commercial agentic pentesting platform that closes the full AppSec lifecycle and runs an enhanced build of Shannon as its pentesting engine.
+**Keygraph** is the company behind Shannon. It also builds the **Keygraph platform**, the commercial agentic pentesting product that closes the full AppSec lifecycle and runs an enhanced build of Shannon as its pentesting engine.
 
 ## Community and Support
 
@@ -880,7 +880,7 @@ Shannon currently targets exploitable vulnerabilities in these classes:
 
 Shannon's proof-by-exploitation model means it does not report issues it cannot actively exploit, such as many vulnerable dependency, insecure configuration, or broad policy findings.
 
-For broader coverage, Keygraph adds black-box and white-box agentic pentesting, graph-based static analysis, SCA reachability, secrets detection, business logic testing, remediation workflows, SLA tracking, and reporting dashboards.
+For broader coverage, the Keygraph platform adds black-box and white-box agentic pentesting, graph-based static analysis, SCA reachability, secrets detection, business logic testing, remediation workflows, SLA tracking, and reporting dashboards.
 
 ## Cost and Performance
 
@@ -914,21 +914,21 @@ This reduces speculative noise, but it also means Shannon does not aim to report
 
 Planned coverage areas should continue to live in the repository's canonical roadmap document if one exists. The README should link to that document rather than carrying detailed roadmap history inline.
 
-For organizations that need broader static and organizational coverage now, see [Keygraph](keygraph-platform.md).
+For organizations that need broader static and organizational coverage now, see [the Keygraph platform](keygraph-platform.md).
 
 ---
 
 # File: docs/keygraph-platform.md
 
-# Keygraph
+# Keygraph Platform
 
-Keygraph is the commercial continuous pentesting and AppSec platform for teams running security across many repositories, services, and environments. While Shannon is a local white-box pentesting CLI, Keygraph is a full platform: it combines parsed-code SAST, source-to-sink analysis, black-box and white-box agentic pentesting, verified remediation, CI/CD gating, SLA tracking, and reporting for security and compliance teams.
+The Keygraph platform is Keygraph's commercial continuous pentesting and AppSec platform for teams running security across many repositories, services, and environments. While Shannon is a local white-box pentesting CLI, the Keygraph platform is a complete AppSec system: it combines parsed-code SAST, source-to-sink analysis, black-box and white-box agentic pentesting, verified remediation, CI/CD gating, SLA tracking, and reporting for security and compliance teams.
 
-This repository contains Shannon, the AGPL-3.0 open-source CLI for strictly white-box pentesting. Keygraph supports both white-box and black-box agentic pentesting and adds static analysis, finding management, remediation workflows, reporting, and enterprise deployment options.
+This repository contains Shannon, the AGPL-3.0 open-source CLI for strictly white-box pentesting. The Keygraph platform supports both white-box and black-box agentic pentesting and adds static analysis, finding management, remediation workflows, reporting, and enterprise deployment options.
 
-## Who Should Consider Keygraph
+## Who Should Consider the Keygraph Platform
 
-Keygraph is intended for organizations that need:
+The Keygraph platform is intended for organizations that need:
 
 - Continuous AppSec coverage across many repositories and services
 - White-box pentesting when source code is available
@@ -943,7 +943,7 @@ Keygraph is intended for organizations that need:
 
 ## Full Vulnerability Lifecycle
 
-Keygraph is designed to cover the full vulnerability lifecycle, not only discovery:
+The Keygraph platform is designed to cover the full vulnerability lifecycle, not only discovery:
 
 1. **Find** exploitable issues with white-box pentesting, black-box pentesting, SAST, SCA, secrets, IaC, container, and business logic testing.
 2. **Normalize** results into canonical findings so duplicate scanner outputs become one tracked vulnerability per repository.
@@ -958,7 +958,7 @@ Keygraph is designed to cover the full vulnerability lifecycle, not only discove
 
 Shannon is strictly white-box: it requires access to the target application's source code and repository layout.
 
-Keygraph supports two pentesting modes:
+The Keygraph platform supports two pentesting modes:
 
 - **White-box agentic pentesting**: Agents use source-code context to understand architecture, identify realistic attack paths, and validate exploitability against the running application.
 - **Black-box agentic pentesting**: Agents test deployed applications and APIs without source-code access, useful for third-party surfaces, production-like external validation, or environments where source access is unavailable.
@@ -967,7 +967,7 @@ Both modes follow the same core principle: do not report what might be vulnerabl
 
 ## AppSec Coverage
 
-Keygraph combines agentic pentesting with broader AppSec coverage:
+The Keygraph platform combines agentic pentesting with broader AppSec coverage:
 
 - **Agentic SAST**: Code Property Graph analysis with LLM reasoning for data flow, context, and sanitization decisions.
 - **SCA with reachability**: Dependency vulnerability analysis that prioritizes issues reachable from application entry points.
@@ -984,7 +984,7 @@ The result is a finding with proof of exploitability, source context when availa
 
 ## Enterprise Deployment
 
-Keygraph supports enterprise deployment patterns for teams with strict data, model, and network requirements:
+The Keygraph platform supports enterprise deployment patterns for teams with strict data, model, and network requirements:
 
 - **Self-hosted deployments** inside the customer's cloud or infrastructure
 - **Air-gapped deployments** for isolated environments
@@ -997,7 +997,7 @@ Deployments can be designed so source code, scan results, prompts, completions, 
 
 ## Capability Comparison
 
-| Need | Shannon | Keygraph |
+| Need | Shannon | Keygraph platform |
 | --- | --- | --- |
 | Licensing | AGPL-3.0 | Commercial |
 | White-box pentesting | Yes; source code required | Yes; source-aware testing with platform workflows |

--- a/llms.txt
+++ b/llms.txt
@@ -1,12 +1,12 @@
 # Shannon
 
-> Shannon is an autonomous AI pentesting project by Keygraph. This repository contains Shannon, the AGPL-3.0 open-source white-box pentesting CLI. Keygraph is the commercial continuous pentesting and AppSec platform.
+> Shannon is an autonomous AI pentesting project by Keygraph. This repository contains Shannon, the AGPL-3.0 open-source white-box pentesting CLI. The Keygraph platform is Keygraph's commercial continuous pentesting and AppSec platform.
 
 Use this file as the concise entry point for AI agents and LLMs reading this repository. For a single combined context file, use [llms-full.txt](llms-full.txt).
 
 ## Start Here
 
-- [README](README.md): Main project overview, editions, quick start, Shannon capabilities, Keygraph positioning, safety notes, licensing, and support links.
+- [README](README.md): Main project overview, editions, quick start, Shannon capabilities, Keygraph platform positioning, safety notes, licensing, and support links.
 - [Full Combined Context](llms-full.txt): README and documentation combined into one file for agents that need maximum local context.
 
 ## Shannon
@@ -19,9 +19,9 @@ Use this file as the concise entry point for AI agents and LLMs reading this rep
 - [Safety and Limitations](docs/safety.md): Authorized-use requirements, non-production guidance, mutative effects, model caveats, scope limits, cost, and performance.
 - [Coverage and Roadmap](docs/coverage-roadmap.md): Current Shannon coverage and roadmap direction.
 
-## Keygraph
+## Keygraph Platform
 
-- [Keygraph](docs/keygraph-platform.md): Commercial continuous pentesting and AppSec platform, including black-box and white-box pentesting, parsed-code SAST, source-to-sink analysis, remediation workflows, CI/CD gating, SLA tracking, reporting, and enterprise deployment.
+- [Keygraph platform](docs/keygraph-platform.md): Commercial continuous pentesting and AppSec platform, including black-box and white-box pentesting, parsed-code SAST, source-to-sink analysis, remediation workflows, CI/CD gating, SLA tracking, reporting, and enterprise deployment.
 
 ## External Links
 


### PR DESCRIPTION
## Problem

The repo used **Keygraph** to refer to *both* the company and the commercial product. The clearest example was the README's **About Keygraph** section:

> **Keygraph** is the company behind Shannon. It also builds **Keygraph**, the commercial agentic pentesting platform...

The same conflation ran through the Editions section, the comparison tables, `docs/keygraph-platform.md` (whose H1 was literally `# Keygraph`), and the `llms.txt` / `llms-full.txt` mirrors.

## Fix

One consistent convention everywhere:

- **The company → "Keygraph"** — unchanged (e.g. "AI Pentester by Keygraph", "Keygraph is the company behind Shannon", "Keygraph is not responsible for misuse", social links, the `KeygraphHQ/shannon` clone URL).
- **The commercial product → "the Keygraph platform"** — applied throughout.

Where "the Keygraph platform" was immediately followed by a "...platform" descriptor, the descriptor was reworded (e.g. "...commercial pentesting **product**") to avoid stutter.

### Files

- `README.md` — company/product references disambiguated.
- `docs/keygraph-platform.md` — retitled `# Keygraph` → `# Keygraph Platform`; product referred to as "the Keygraph platform" throughout (it's the platform overview, not a company page).
- `docs/coverage-roadmap.md`, `docs/safety.md` — product references updated; the "Keygraph is not responsible for misuse" line stays as the company.
- `llms.txt`, `llms-full.txt` — kept in sync with the README/docs they mirror so the combined-context files don't reintroduce the conflation.

## Notes

- **No filenames changed.** `git diff --name-status -M` against `main` is all `M`, no renames. (The earlier `docs/shannon-pro.md` → `docs/keygraph-platform.md` rename landed in #368; this PR only edits content and links to the current name.)
- No links, package names (`@keygraph/shannon`), or `keygraph.io` URLs were altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)