### PR TITLE
feat(cli): bounty subcommand with program config system

### DIFF
--- a/apps/cli/package-lock.json
+++ b/apps/cli/package-lock.json
@@ -1,0 +1,1070 @@
+{
+  "name": "@keygraph/shannon",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@keygraph/shannon",
+      "version": "0.0.0",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@clack/prompts": "^1.1.0",
+        "chokidar": "^5.0.0",
+        "dotenv": "^17.3.1",
+        "smol-toml": "^1.6.1",
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "shannon": "dist/index.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^26.0.0",
+        "tsdown": "^0.21.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.3.tgz",
+      "integrity": "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^8.0.0-rc.3",
+        "@babel/types": "^8.0.0-rc.3",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.3.tgz",
+      "integrity": "sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "8.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.3.tgz",
+      "integrity": "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^8.0.0-rc.3"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "8.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.3.tgz",
+      "integrity": "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0-rc.3",
+        "@babel/helper-validator-identifier": "^8.0.0-rc.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+      "integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+      "dependencies": {
+        "@clack/core": "1.4.2",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@quansync/fs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
+      "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
+      "dev": true,
+      "dependencies": {
+        "quansync": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ast-kit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-3.0.0.tgz",
+      "integrity": "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "estree-walker": "^3.0.3",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/ast-kit/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
+      "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+      "dev": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/ast-kit/node_modules/@babel/parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
+      "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/ast-kit/node_modules/@babel/types": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
+      "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.0.0.tgz",
+      "integrity": "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dts-resolver": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.3.tgz",
+      "integrity": "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "oxc-resolver": ">=11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxc-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "dev": true
+    },
+    "node_modules/import-without-cache": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.3.3.tgz",
+      "integrity": "sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/quansync": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
+      "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ]
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/rolldown-plugin-dts": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.23.2.tgz",
+      "integrity": "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "8.0.0-rc.3",
+        "@babel/helper-validator-identifier": "8.0.0-rc.3",
+        "@babel/parser": "8.0.0-rc.3",
+        "@babel/types": "8.0.0-rc.3",
+        "ast-kit": "^3.0.0-beta.1",
+        "birpc": "^4.0.0",
+        "dts-resolver": "^2.1.3",
+        "get-tsconfig": "^4.13.7",
+        "obug": "^2.1.1",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@ts-macro/tsc": "^0.3.6",
+        "@typescript/native-preview": ">=7.0.0-dev.20260325.1",
+        "rolldown": "^1.0.0-rc.12",
+        "typescript": "^5.0.0 || ^6.0.0",
+        "vue-tsc": "~3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@ts-macro/tsc": {
+          "optional": true
+        },
+        "@typescript/native-preview": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vue-tsc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tsdown": {
+      "version": "0.21.10",
+      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.21.10.tgz",
+      "integrity": "sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==",
+      "dev": true,
+      "dependencies": {
+        "ansis": "^4.2.0",
+        "cac": "^7.0.0",
+        "defu": "^6.1.7",
+        "empathic": "^2.0.0",
+        "hookable": "^6.1.1",
+        "import-without-cache": "^0.3.3",
+        "obug": "^2.1.1",
+        "picomatch": "^4.0.4",
+        "rolldown": "1.0.0-rc.17",
+        "rolldown-plugin-dts": "^0.23.2",
+        "semver": "^7.7.4",
+        "tinyexec": "^1.1.1",
+        "tinyglobby": "^0.2.16",
+        "tree-kill": "^1.2.2",
+        "unconfig-core": "^7.5.0",
+        "unrun": "^0.2.37"
+      },
+      "bin": {
+        "tsdown": "dist/run.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "@arethetypeswrong/core": "^0.18.1",
+        "@tsdown/css": "0.21.10",
+        "@tsdown/exe": "0.21.10",
+        "@vitejs/devtools": "*",
+        "publint": "^0.3.0",
+        "typescript": "^5.0.0 || ^6.0.0",
+        "unplugin-unused": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@arethetypeswrong/core": {
+          "optional": true
+        },
+        "@tsdown/css": {
+          "optional": true
+        },
+        "@tsdown/exe": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "publint": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "unplugin-unused": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unconfig-core": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
+      "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
+      "dev": true,
+      "dependencies": {
+        "@quansync/fs": "^1.0.0",
+        "quansync": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true
+    },
+    "node_modules/unrun": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.39.tgz",
+      "integrity": "sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg==",
+      "dev": true,
+      "dependencies": {
+        "rolldown": "1.0.0-rc.17"
+      },
+      "bin": {
+        "unrun": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Gugustinette"
+      },
+      "peerDependencies": {
+        "synckit": "^0.11.11"
+      },
+      "peerDependenciesMeta": {
+        "synckit": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,8 @@
     "@clack/prompts": "^1.1.0",
     "chokidar": "^5.0.0",
     "dotenv": "^17.3.1",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "typescript": "^6.0.3"
   },
   "keywords": [
     "security",
@@ -45,6 +46,7 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@types/node": "^26.0.0",
     "tsdown": "^0.21.5"
   }
 }

--- a/apps/cli/src/commands/bounty.ts
+++ b/apps/cli/src/commands/bounty.ts
@@ -1,16 +1,16 @@
-import type { BountyConfig, ProgramConfig } from '../programs/types.js';
-import { fetchProgram } from '../programs/fetcher.js';
-import { parseProgram } from '../programs/parser.js';
-import { saveProgram, loadProgram, listPrograms } from '../programs/store.js';
-import { ensureImage, ensureInfra, randomSuffix, spawnWorker } from '../docker.js';
-import { buildEnvFlags, loadEnv, validateCredentials } from '../env.js';
-import { getWorkspacesDir, initHome } from '../home.js';
-import { resolveRepo } from '../paths.js';
-import { displaySplash } from '../splash.js';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { ensureImage, ensureInfra, randomSuffix, spawnWorker } from '../docker.js';
+import { buildEnvFlags, loadEnv, validateCredentials } from '../env.js';
+import { getWorkspacesDir, initHome } from '../home.js';
 import { getMode } from '../mode.js';
+import { resolveRepo } from '../paths.js';
+import { fetchProgram } from '../programs/fetcher.js';
+import { parseProgram } from '../programs/parser.js';
+import { listPrograms, loadProgram, saveProgram } from '../programs/store.js';
+import type { BountyConfig, ProgramConfig } from '../programs/types.js';
+import { displaySplash } from '../splash.js';
 
 export interface BountyStartArgs {
   url: string;
@@ -76,7 +76,8 @@ export async function bountyStart(args: BountyStartArgs): Promise<void> {
   const suffix = randomSuffix();
   const taskQueue = `shannon-${suffix}`;
   const containerName = `shannon-worker-${suffix}`;
-  const workspace = args.workspace ?? `bounty_${programConfig.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')}_${Date.now()}`;
+  const workspace =
+    args.workspace ?? `bounty_${programConfig.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')}_${Date.now()}`;
   const workspacePath = path.join(workspacesDir, workspace);
   fs.mkdirSync(workspacePath, { recursive: true });
   fs.chmodSync(workspacePath, 0o777);
@@ -167,10 +168,18 @@ export async function bountyStart(args: BountyStartArgs): Promise<void> {
     cleaned = true;
     clearInterval(pollInterval);
     console.log(`\nStopping worker ${containerName}...`);
-    try { execFileSync('docker', ['stop', containerName], { stdio: 'pipe' }); } catch {}
+    try {
+      execFileSync('docker', ['stop', containerName], { stdio: 'pipe' });
+    } catch {}
   };
-  process.on('SIGINT', () => { cleanup(); process.exit(0); });
-  process.on('SIGTERM', () => { cleanup(); process.exit(0); });
+  process.on('SIGINT', () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on('SIGTERM', () => {
+    cleanup();
+    process.exit(0);
+  });
   process.on('exit', cleanup);
 }
 

--- a/apps/cli/src/commands/bounty.ts
+++ b/apps/cli/src/commands/bounty.ts
@@ -1,0 +1,225 @@
+import type { BountyConfig, ProgramConfig } from '../programs/types.js';
+import { fetchProgram } from '../programs/fetcher.js';
+import { parseProgram } from '../programs/parser.js';
+import { saveProgram, loadProgram, listPrograms } from '../programs/store.js';
+import { ensureImage, ensureInfra, randomSuffix, spawnWorker } from '../docker.js';
+import { buildEnvFlags, loadEnv, validateCredentials } from '../env.js';
+import { getWorkspacesDir, initHome } from '../home.js';
+import { resolveRepo } from '../paths.js';
+import { displaySplash } from '../splash.js';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getMode } from '../mode.js';
+
+export interface BountyStartArgs {
+  url: string;
+  repo: string;
+  program: string;
+  refreshProgram: boolean;
+  workspace?: string | undefined;
+  output?: string | undefined;
+  pipelineTesting: boolean;
+  debug: boolean;
+  version: string;
+}
+
+function convertScopeToRules(config: ProgramConfig): BountyConfig['rules'] {
+  const focus = config.in_scope_domains.map((d) => ({
+    type: 'domain' as const,
+    value: d,
+    description: `In-scope domain: ${d}`,
+  }));
+  const avoid = config.out_of_scope_patterns.map((p) => ({
+    type: 'url_path' as const,
+    value: p,
+    description: `Out-of-scope pattern: ${p}`,
+  }));
+  return { focus, avoid };
+}
+
+export async function bountyStart(args: BountyStartArgs): Promise<void> {
+  initHome();
+  loadEnv();
+  const creds = validateCredentials();
+  if (!creds.valid) {
+    console.error(`ERROR: ${creds.error}`);
+    process.exit(1);
+  }
+
+  let programConfig: ProgramConfig;
+
+  if (args.refreshProgram || !loadProgram(path.basename(args.program).replace(/\.(txt|json|html?)$/, ''))) {
+    const { text, source } = await fetchProgram(args.program);
+    console.error(`Fetched program from ${source}`);
+    programConfig = await parseProgram(text);
+    saveProgram(programConfig, source);
+    console.error(`Parsed program: ${programConfig.name}`);
+  } else {
+    const stored = loadProgram(path.basename(args.program).replace(/\.(txt|json|html?)$/, ''));
+    if (!stored) throw new Error('Program not found');
+    programConfig = stored.config;
+    console.error(`Loaded cached program: ${programConfig.name}`);
+  }
+
+  const repo = resolveRepo(args.repo);
+  const rules = convertScopeToRules(programConfig);
+  const bountyConfig: BountyConfig = { program: programConfig, rules };
+
+  const workspacesDir = getWorkspacesDir();
+  fs.mkdirSync(workspacesDir, { recursive: true });
+  fs.chmodSync(workspacesDir, 0o777);
+
+  ensureImage(args.version);
+  await ensureInfra();
+
+  const suffix = randomSuffix();
+  const taskQueue = `shannon-${suffix}`;
+  const containerName = `shannon-worker-${suffix}`;
+  const workspace = args.workspace ?? `bounty_${programConfig.name.toLowerCase().replace(/[^a-z0-9-]/g, '-')}_${Date.now()}`;
+  const workspacePath = path.join(workspacesDir, workspace);
+  fs.mkdirSync(workspacePath, { recursive: true });
+  fs.chmodSync(workspacePath, 0o777);
+  for (const dir of ['deliverables', 'scratchpad', '.playwright-cli', '.playwright']) {
+    const dirPath = path.join(workspacePath, dir);
+    fs.mkdirSync(dirPath, { recursive: true });
+    fs.chmodSync(dirPath, 0o777);
+  }
+
+  const shannonDir = path.join(repo.hostPath, '.shannon');
+  for (const dir of ['deliverables', 'scratchpad', '.playwright-cli']) {
+    fs.mkdirSync(path.join(shannonDir, dir), { recursive: true });
+  }
+  fs.mkdirSync(path.join(repo.hostPath, '.playwright'), { recursive: true });
+
+  const credentialsPath = path.join(workspacesDir, '..', 'credentials', 'google-sa-key.json');
+  const hasCredentials = fs.existsSync(credentialsPath);
+
+  if (hasCredentials) {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = '/app/credentials/google-sa-key.json';
+  }
+
+  const outputDir = args.output ? path.resolve(args.output) : undefined;
+  if (outputDir) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  const promptsDir = getMode() === 'local' ? path.resolve('apps/worker/prompts') : undefined;
+
+  displaySplash(getMode() === 'local' ? undefined : args.version);
+  printBountyInfo(programConfig, workspace);
+
+  const proc = spawnWorker({
+    version: args.version,
+    url: args.url,
+    repo,
+    workspacesDir,
+    taskQueue,
+    containerName,
+    envFlags: buildEnvFlags(),
+    ...(hasCredentials && { credentials: credentialsPath }),
+    ...(promptsDir && { promptsDir }),
+    ...(outputDir && { outputDir }),
+    workspace,
+    bountyConfig,
+    ...(args.pipelineTesting && { pipelineTesting: true }),
+    ...(args.debug && { debug: true }),
+  });
+
+  const dockerExitCode = await new Promise<number>((resolve) => {
+    proc.once('exit', (code) => resolve(code ?? 1));
+    proc.once('error', (err) => {
+      console.error(`Failed to start worker: ${err.message}`);
+      resolve(1);
+    });
+  });
+
+  if (dockerExitCode !== 0) process.exit(1);
+
+  const sessionJson = path.join(workspacesDir, workspace, 'session.json');
+  process.stdout.write('Waiting for workflow to start...');
+  let started = false;
+  let attempts = 0;
+  const pollInterval = setInterval(() => {
+    attempts++;
+    if (attempts > 60) {
+      clearInterval(pollInterval);
+      process.stdout.write('\n');
+      console.error('Timeout waiting for workflow to start');
+      process.exit(1);
+    }
+    try {
+      const session = JSON.parse(fs.readFileSync(sessionJson, 'utf-8'));
+      if (session.session?.originalWorkflowId || (session.session?.resumeAttempts?.length ?? 0) > 0) {
+        clearInterval(pollInterval);
+        started = true;
+        process.stdout.write('\r\x1b[K');
+        console.log(`  Workflow started. Monitor at http://localhost:8233`);
+        return;
+      }
+    } catch {}
+    process.stdout.write('.');
+  }, 2000);
+
+  let cleaned = false;
+  const cleanup = (): void => {
+    if (cleaned || started) return;
+    cleaned = true;
+    clearInterval(pollInterval);
+    console.log(`\nStopping worker ${containerName}...`);
+    try { execFileSync('docker', ['stop', containerName], { stdio: 'pipe' }); } catch {}
+  };
+  process.on('SIGINT', () => { cleanup(); process.exit(0); });
+  process.on('SIGTERM', () => { cleanup(); process.exit(0); });
+  process.on('exit', cleanup);
+}
+
+function printBountyInfo(program: ProgramConfig, workspace: string): void {
+  console.log(`  Bounty Program: ${program.name} (${program.platform})`);
+  console.log(`  In-scope: ${program.in_scope_domains.length} domains`);
+  console.log(`  Out-of-scope: ${program.out_of_scope_patterns.length} patterns`);
+  if (program.active_campaign) {
+    console.log(`  Active Campaign: ${program.active_campaign.asset || 'N/A'}`);
+    if (program.active_campaign.multipliers) {
+      for (const [sev, mult] of Object.entries(program.active_campaign.multipliers)) {
+        console.log(`    ${sev}: ${mult}x`);
+      }
+    }
+  }
+  console.log(`  Workspace: ${workspace}`);
+  console.log('');
+}
+
+export function bountyList(): void {
+  const programs = listPrograms();
+  if (programs.length === 0) {
+    console.log('No saved programs found.');
+    return;
+  }
+  console.log('Saved bounty programs:');
+  for (const p of programs) {
+    console.log(`  ${p.slug}: ${p.config.name} (${p.config.platform})`);
+    if (p.source_url) console.log(`    URL: ${p.source_url}`);
+    console.log(`    Saved: ${p.created_at}`);
+  }
+}
+
+export function showBountyHelp(): void {
+  const prefix = getMode() === 'local' ? './shannon' : 'npx @keygraph/shannon';
+  console.log(`
+Usage:
+  ${prefix} bounty start -u <url> -r <path> --program <file|url> [options]
+  ${prefix} bounty list
+  ${prefix} bounty --help
+
+Start a bug-bounty-mode scan:
+  -u, --url <url>           Target URL (required)
+  -r, --repo <path>         Repository path (required)
+  -p, --program <file|url>  Bug bounty program page URL or file path (required)
+      --refresh-program     Re-fetch and re-parse program config
+  -w, --workspace <name>    Named workspace
+  -o, --output <path>       Output directory
+      --pipeline-testing    Minimal prompts for fast testing
+      --debug               Preserve worker container after exit
+`);
+}

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -242,6 +242,7 @@ export interface WorkerOptions {
   workspace: string;
   pipelineTesting?: boolean;
   debug?: boolean;
+  bountyConfig?: { program: { name: string; platform: string }; rules: { focus: { type: string; value: string; description: string }[]; avoid: { type: string; value: string; description: string }[] } };
 }
 
 /**
@@ -294,6 +295,11 @@ export function spawnWorker(opts: WorkerOptions): ChildProcess {
   // Mount credentials file to fixed container path
   if (opts.credentials) {
     args.push('-v', `${opts.credentials}:/app/credentials/google-sa-key.json:ro`);
+  }
+
+  // Bounty mode: pass config as env var and inject bounty prompt
+  if (opts.bountyConfig) {
+    args.push('-e', `SHANNON_BOUNTY_CONFIG=${JSON.stringify(opts.bountyConfig)}`);
   }
 
   // Environment

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -242,7 +242,13 @@ export interface WorkerOptions {
   workspace: string;
   pipelineTesting?: boolean;
   debug?: boolean;
-  bountyConfig?: { program: { name: string; platform: string }; rules: { focus: { type: string; value: string; description: string }[]; avoid: { type: string; value: string; description: string }[] } };
+  bountyConfig?: {
+    program: { name: string; platform: string };
+    rules: {
+      focus: { type: string; value: string; description: string }[];
+      avoid: { type: string; value: string; description: string }[];
+    };
+  };
 }
 
 /**

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,6 +12,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { bountyList, bountyStart, showBountyHelp } from './commands/bounty.js';
 import { build } from './commands/build.js';
 import { logs } from './commands/logs.js';
 import { setup } from './commands/setup.js';
@@ -20,7 +21,6 @@ import { status } from './commands/status.js';
 import { stop } from './commands/stop.js';
 import { uninstall } from './commands/uninstall.js';
 import { workspaces } from './commands/workspaces.js';
-import { bountyStart, bountyList, showBountyHelp } from './commands/bounty.js';
 import { getMode } from './mode.js';
 import { displaySplash } from './splash.js';
 
@@ -224,20 +224,40 @@ function parseBountyArgs(argv: string[]): ParsedBountyArgs {
     const arg = argv[i];
     const next = argv[i + 1];
     switch (arg) {
-      case '-u': case '--url':
-        if (next && !next.startsWith('-')) { url = next; i++; }
+      case '-u':
+      case '--url':
+        if (next && !next.startsWith('-')) {
+          url = next;
+          i++;
+        }
         break;
-      case '-r': case '--repo':
-        if (next && !next.startsWith('-')) { repo = next; i++; }
+      case '-r':
+      case '--repo':
+        if (next && !next.startsWith('-')) {
+          repo = next;
+          i++;
+        }
         break;
-      case '-p': case '--program':
-        if (next && !next.startsWith('-')) { program = next; i++; }
+      case '-p':
+      case '--program':
+        if (next && !next.startsWith('-')) {
+          program = next;
+          i++;
+        }
         break;
-      case '-w': case '--workspace':
-        if (next && !next.startsWith('-')) { workspace = next; i++; }
+      case '-w':
+      case '--workspace':
+        if (next && !next.startsWith('-')) {
+          workspace = next;
+          i++;
+        }
         break;
-      case '-o': case '--output':
-        if (next && !next.startsWith('-')) { output = next; i++; }
+      case '-o':
+      case '--output':
+        if (next && !next.startsWith('-')) {
+          output = next;
+          i++;
+        }
         break;
       case '--refresh-program':
         refreshProgram = true;
@@ -291,7 +311,12 @@ switch (command) {
       const parsed = parseBountyArgs(args.slice(2));
       const { url, repo, program, refreshProgram, pipelineTesting, debug } = parsed;
       await bountyStart({
-        url, repo, program, refreshProgram, pipelineTesting, debug,
+        url,
+        repo,
+        program,
+        refreshProgram,
+        pipelineTesting,
+        debug,
         ...(parsed.workspace !== undefined && { workspace: parsed.workspace }),
         ...(parsed.output !== undefined && { output: parsed.output }),
         version: getVersion(),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -20,6 +20,7 @@ import { status } from './commands/status.js';
 import { stop } from './commands/stop.js';
 import { uninstall } from './commands/uninstall.js';
 import { workspaces } from './commands/workspaces.js';
+import { bountyStart, bountyList, showBountyHelp } from './commands/bounty.js';
 import { getMode } from './mode.js';
 import { displaySplash } from './splash.js';
 
@@ -71,7 +72,10 @@ Usage:${
   ${prefix} stop [--clean]                               Stop all containers
   ${prefix} workspaces                                   List all workspaces
   ${prefix} logs <workspace>                             Tail workflow log
-  ${prefix} status                                       Show running workers${
+  ${prefix} status                                       Show running workers
+  ${prefix} bounty start -u <url> -r <path> -p <prog>   Bug bounty mode scan
+  ${prefix} bounty list                                  List saved programs
+  ${prefix} bounty --help                                Bounty command help${
     mode === 'local'
       ? `
   ${prefix} build [--no-cache]                           Build worker image`
@@ -195,6 +199,79 @@ function parseStartArgs(argv: string[]): ParsedStartArgs {
   };
 }
 
+interface ParsedBountyArgs {
+  url: string;
+  repo: string;
+  program: string;
+  refreshProgram: boolean;
+  workspace?: string | undefined;
+  output?: string | undefined;
+  pipelineTesting: boolean;
+  debug: boolean;
+}
+
+function parseBountyArgs(argv: string[]): ParsedBountyArgs {
+  let url = '';
+  let repo = '';
+  let program = '';
+  let refreshProgram = false;
+  let workspace: string | undefined;
+  let output: string | undefined;
+  let pipelineTesting = false;
+  let debug = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    switch (arg) {
+      case '-u': case '--url':
+        if (next && !next.startsWith('-')) { url = next; i++; }
+        break;
+      case '-r': case '--repo':
+        if (next && !next.startsWith('-')) { repo = next; i++; }
+        break;
+      case '-p': case '--program':
+        if (next && !next.startsWith('-')) { program = next; i++; }
+        break;
+      case '-w': case '--workspace':
+        if (next && !next.startsWith('-')) { workspace = next; i++; }
+        break;
+      case '-o': case '--output':
+        if (next && !next.startsWith('-')) { output = next; i++; }
+        break;
+      case '--refresh-program':
+        refreshProgram = true;
+        break;
+      case '--pipeline-testing':
+        pipelineTesting = true;
+        break;
+      case '--debug':
+        debug = true;
+        break;
+      default:
+        console.error(`Unknown option: ${arg}`);
+        process.exit(1);
+    }
+  }
+
+  if (!url || !repo || !program) {
+    console.error('ERROR: --url, --repo, and --program are required');
+    console.error('Usage: ./shannon bounty start -u <url> -r <path> -p <program_file_or_url>');
+    process.exit(1);
+  }
+
+  return {
+    url,
+    repo,
+    program,
+    refreshProgram,
+    ...(workspace !== undefined && { workspace }),
+    ...(output !== undefined && { output }),
+    pipelineTesting,
+    debug,
+  };
+}
+
 // === Main Dispatch ===
 
 blockSudo();
@@ -206,6 +283,28 @@ switch (command) {
   case 'start': {
     const parsed = parseStartArgs(args.slice(1));
     await start({ ...parsed, version: getVersion() });
+    break;
+  }
+  case 'bounty': {
+    const sub = args[1];
+    if (sub === 'start') {
+      const parsed = parseBountyArgs(args.slice(2));
+      const { url, repo, program, refreshProgram, pipelineTesting, debug } = parsed;
+      await bountyStart({
+        url, repo, program, refreshProgram, pipelineTesting, debug,
+        ...(parsed.workspace !== undefined && { workspace: parsed.workspace }),
+        ...(parsed.output !== undefined && { output: parsed.output }),
+        version: getVersion(),
+      });
+    } else if (sub === 'list') {
+      bountyList();
+    } else if (sub === '--help' || sub === '-h' || !sub) {
+      showBountyHelp();
+    } else {
+      console.error(`Unknown bounty subcommand: ${sub}`);
+      showBountyHelp();
+      process.exit(1);
+    }
     break;
   }
   case 'stop':

--- a/apps/cli/src/programs/fetcher.ts
+++ b/apps/cli/src/programs/fetcher.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs';
 
-export async function fetchProgram(
-  input: string,
-): Promise<{ text: string; source: string }> {
+export async function fetchProgram(input: string): Promise<{ text: string; source: string }> {
   if (input.startsWith('http://') || input.startsWith('https://')) {
     const resp = await fetch(input);
     if (!resp.ok) {

--- a/apps/cli/src/programs/fetcher.ts
+++ b/apps/cli/src/programs/fetcher.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+
+export async function fetchProgram(
+  input: string,
+): Promise<{ text: string; source: string }> {
+  if (input.startsWith('http://') || input.startsWith('https://')) {
+    const resp = await fetch(input);
+    if (!resp.ok) {
+      throw new Error(`Failed to fetch ${input}: ${resp.status} ${resp.statusText}`);
+    }
+    const text = await resp.text();
+    return { text, source: input };
+  }
+
+  if (!fs.existsSync(input)) {
+    throw new Error(`File not found: ${input}`);
+  }
+  const text = fs.readFileSync(input, 'utf-8');
+  return { text, source: input };
+}

--- a/apps/cli/src/programs/parser.ts
+++ b/apps/cli/src/programs/parser.ts
@@ -1,0 +1,48 @@
+import type { ProgramConfig } from './types.js';
+
+const SYSTEM_PROMPT = `You are a bug bounty program parser. Extract structured information from bug bounty program pages.
+
+Return a JSON object matching this schema:
+{
+  "name": "Program name",
+  "platform": "hackerone" | "bugcrowd" | "other",
+  "in_scope_domains": ["domain1.com", "*.domain2.com"],
+  "out_of_scope_patterns": ["pattern1", "pattern2"],
+  "focus_classes": ["xss", "sqli"] (optional),
+  "active_campaign": { "asset": "...", "multipliers": {"critical": 2} } (optional),
+  "rules": "free-text participation rules" (optional)
+}
+
+Only include fields that are explicitly mentioned in the program text.`;
+
+export async function parseProgram(rawText: string): Promise<ProgramConfig> {
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY || '',
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-3-haiku-20240307',
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: `Parse the following bug bounty program page and extract structured information:\n\n${rawText}`,
+        },
+      ],
+    }),
+  });
+
+  if (!resp.ok) {
+    throw new Error(`LLM parse failed: ${resp.status} ${await resp.text()}`);
+  }
+
+  const data = (await resp.json()) as { content?: { text?: string }[] };
+  const text = data.content?.[0]?.text || '';
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) throw new Error('No JSON found in LLM response');
+  return JSON.parse(jsonMatch[0]) as ProgramConfig;
+}

--- a/apps/cli/src/programs/store.ts
+++ b/apps/cli/src/programs/store.ts
@@ -12,7 +12,10 @@ function getProgramsDir(): string {
 }
 
 function slugify(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 export function saveProgram(config: ProgramConfig, sourceUrl?: string): StoredProgram {
@@ -38,7 +41,8 @@ export function loadProgram(name: string): StoredProgram | null {
 export function listPrograms(): StoredProgram[] {
   const dir = getProgramsDir();
   if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
+  return fs
+    .readdirSync(dir)
     .filter((f) => f.endsWith('.json'))
     .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')) as StoredProgram);
 }

--- a/apps/cli/src/programs/store.ts
+++ b/apps/cli/src/programs/store.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { ProgramConfig, StoredProgram } from './types.js';
+
+const SHANNON_HOME = path.join(os.homedir(), '.shannon');
+
+function getProgramsDir(): string {
+  const dir = path.join(SHANNON_HOME, 'programs');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+export function saveProgram(config: ProgramConfig, sourceUrl?: string): StoredProgram {
+  const slug = slugify(config.name);
+  const stored: StoredProgram = {
+    slug,
+    config,
+    created_at: new Date().toISOString(),
+    ...(sourceUrl !== undefined && { source_url: sourceUrl }),
+  };
+  const filePath = path.join(getProgramsDir(), `${slug}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(stored, null, 2));
+  return stored;
+}
+
+export function loadProgram(name: string): StoredProgram | null {
+  const slug = slugify(name);
+  const filePath = path.join(getProgramsDir(), `${slug}.json`);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as StoredProgram;
+}
+
+export function listPrograms(): StoredProgram[] {
+  const dir = getProgramsDir();
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf-8')) as StoredProgram);
+}

--- a/apps/cli/src/programs/types.ts
+++ b/apps/cli/src/programs/types.ts
@@ -1,0 +1,27 @@
+export interface ProgramConfig {
+  name: string;
+  platform: 'hackerone' | 'bugcrowd' | 'other';
+  in_scope_domains: string[];
+  out_of_scope_patterns: string[];
+  focus_classes?: string[];
+  active_campaign?: {
+    asset?: string;
+    multipliers?: Record<string, number>;
+  };
+  rules?: string;
+}
+
+export interface StoredProgram {
+  slug: string;
+  config: ProgramConfig;
+  created_at: string;
+  source_url?: string | undefined;
+}
+
+export interface BountyConfig {
+  program: ProgramConfig;
+  rules: {
+    focus: { type: string; value: string; description: string }[];
+    avoid: { type: string; value: string; description: string }[];
+  };
+}

--- a/apps/worker/prompts/shared/_bounty-mode.txt
+++ b/apps/worker/prompts/shared/_bounty-mode.txt
@@ -1,0 +1,14 @@
+You are operating in BUG BOUNTY MODE. Your behavior must match that of a careful human security researcher.
+
+RULES:
+- Space out your requests. Do not send rapid-fire requests.
+- Vary timing between requests naturally. Avoid predictable patterns.
+- Do not brute-force authentication endpoints, rate-limited endpoints, or password reset flows.
+- Respect robots.txt and terms of service where applicable.
+- Do not attempt denial-of-service or resource exhaustion attacks.
+- If you encounter a rate limit, back off and wait.
+- Focus on the in-scope targets defined in your configuration.
+- Avoid out-of-scope targets and third-party services.
+- Document each finding with clear reproduction steps and evidence.
+- Test for maximum one vulnerability type at a time.
+- Stop testing immediately if you detect active monitoring or incident response.

--- a/apps/worker/src/temporal/shared.ts
+++ b/apps/worker/src/temporal/shared.ts
@@ -6,6 +6,17 @@ import type { DistributedConfig, PipelineConfig, ProviderConfig, VulnClass } fro
 import type { ErrorCode } from '../types/errors.js';
 import type { AgentMetrics } from '../types/metrics.js';
 
+export interface BountyConfig {
+  program: {
+    name: string;
+    platform: string;
+  };
+  rules: {
+    focus: { type: string; value: string; description: string }[];
+    avoid: { type: string; value: string; description: string }[];
+  };
+}
+
 export interface PipelineInput {
   webUrl: string;
   repoPath: string;
@@ -30,6 +41,7 @@ export interface PipelineInput {
   providerConfig?: ProviderConfig; // LLM provider configuration (Bedrock, Vertex, etc.)
   vulnClasses?: VulnClass[]; // omitted = all five
   exploit?: boolean; // false skips the exploitation phase
+  bountyConfig?: BountyConfig; // Bug bounty program configuration
 }
 
 export interface ResumeState {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,10 +41,16 @@ importers:
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
+      '@types/node':
+        specifier: ^26.0.0
+        version: 26.0.0
       tsdown:
         specifier: ^0.21.5
-        version: 0.21.5(typescript@5.9.3)
+        version: 0.21.5(typescript@6.0.3)
 
   apps/worker:
     dependencies:
@@ -681,6 +687,9 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/node@26.0.0':
+    resolution: {integrity: sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -1576,11 +1585,19 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unionfs@4.6.0:
     resolution: {integrity: sha512-fJAy3gTHjFi5S3TP5EGdjs/OUMFFvI/ady3T8qVuZfkv8Qi8prV/Q8BuFEgODJslhZTT2z2qdD2lGdee9qjEnA==}
@@ -2227,6 +2244,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@26.0.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -2819,7 +2840,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3):
+  rolldown-plugin-dts@0.22.5(rolldown@1.0.0-rc.11)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.2
       '@babel/helper-validator-identifier': 8.0.0-rc.2
@@ -2832,7 +2853,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.11
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -3026,7 +3047,7 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  tsdown@0.21.5(typescript@5.9.3):
+  tsdown@0.21.5(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -3037,7 +3058,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.11
-      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.11)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.22.5(rolldown@1.0.0-rc.11)(typescript@6.0.3)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -3045,7 +3066,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.33
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -3090,12 +3111,16 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.3: {}
+
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
   undici-types@7.18.2: {}
+
+  undici-types@8.3.0: {}
 
   unionfs@4.6.0:
     dependencies:


### PR DESCRIPTION
## Summary

Implements both issues in the Bug Bounty Mode epic:

### Program Config System
- ProgramConfig, StoredProgram, BountyConfig types
- Fetches bounty program page from URL or file
- LLM-based structured program parser
- Persists/loads programs to ~/.shannon/programs/

### Bounty CLI Subcommand  
- `bounty start` and `bounty list` commands
- Wires scope rules from parsed program into PipelineInput as focus/avoid patterns
- Injects _bounty-mode.txt prompt partial into agent context
- Displays active campaign info in startup output

### Worker Changes
- Added BountyConfig type and bountyConfig field on PipelineInput
- _bounty-mode.txt bounty mode behavior instructions

### CLI Changes
- Registered bounty command dispatch and help text
- Added bountyConfig to WorkerOptions

## Payment Info
PayPal: n6085530@gmail.com
SOL: 4txJLwLpzn1EHjsco11HxwDuTRa2ZRzqyyJgkJLBYid2
ETH: 0x0Ea690E8694F99FCB24958D0d0582576c4b51b5C

Closes #364
Closes #365