### PR TITLE
fix: CLI setup-command/color UX and harden save-deliverable path handling

### DIFF
--- a/apps/cli/src/config/resolver.ts
+++ b/apps/cli/src/config/resolver.ts
@@ -270,7 +270,7 @@ export function resolveConfig(): void {
     for (const err of errors) {
       console.error(`  - ${err}`);
     }
-    console.error(`\nRun 'shn setup' to reconfigure.\n`);
+    console.error(`\nRun 'npx @keygraph/shannon setup' to reconfigure.\n`);
     process.exit(1);
   }
 

--- a/apps/cli/src/splash.ts
+++ b/apps/cli/src/splash.ts
@@ -2,13 +2,28 @@
  * Splash screen display — pure terminal output, no npm dependencies.
  */
 
+/**
+ * Decide whether to emit ANSI color codes.
+ *
+ * Honors the NO_COLOR convention (https://no-color.org): any non-empty value
+ * disables color. FORCE_COLOR opts back in even when stdout is not a terminal.
+ * Otherwise color is only emitted when writing to an interactive TTY, so the
+ * escape codes don't leak into piped or redirected output.
+ */
+function shouldUseColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR) return true;
+  return process.stdout.isTTY === true;
+}
+
 export function displaySplash(version?: string): void {
-  const GOLD = '\x1b[38;2;244;197;66m';
-  const CYAN = '\x1b[36;1m';
-  const WHITE = '\x1b[1;37m';
-  const GRAY = '\x1b[0;37m';
-  const YELLOW = '\x1b[1;33m';
-  const RESET = '\x1b[0m';
+  const useColor = shouldUseColor();
+  const GOLD = useColor ? '\x1b[38;2;244;197;66m' : '';
+  const CYAN = useColor ? '\x1b[36;1m' : '';
+  const WHITE = useColor ? '\x1b[1;37m' : '';
+  const GRAY = useColor ? '\x1b[0;37m' : '';
+  const YELLOW = useColor ? '\x1b[1;33m' : '';
+  const RESET = useColor ? '\x1b[0m' : '';
 
   const B = `${CYAN}\u2551${RESET}`;
   const S67 = ' '.repeat(67);

--- a/apps/worker/src/scripts/save-deliverable.ts
+++ b/apps/worker/src/scripts/save-deliverable.ts
@@ -16,7 +16,8 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { DEFAULT_DELIVERABLES_SUBDIR, deliverablesDir } from '../paths.js';
 import { DELIVERABLE_FILENAMES, type DeliverableType } from '../types/deliverables.js';
 
 // === Help ===
@@ -77,14 +78,14 @@ function parseArgs(argv: string[]): ParsedArgs {
 // === File Operations ===
 
 function saveDeliverableFile(targetDir: string, filename: string, content: string): string {
-  const subdir = process.env.SHANNON_DELIVERABLES_SUBDIR || '.shannon/deliverables';
-  const deliverablesDir = join(targetDir, ...subdir.split('/'));
-  const filepath = join(deliverablesDir, filename);
+  const subdir = process.env.SHANNON_DELIVERABLES_SUBDIR || DEFAULT_DELIVERABLES_SUBDIR;
+  const targetSubdir = deliverablesDir(targetDir, subdir);
+  const filepath = join(targetSubdir, filename);
 
   try {
-    mkdirSync(deliverablesDir, { recursive: true });
+    mkdirSync(targetSubdir, { recursive: true });
   } catch {
-    throw new Error(`Cannot create deliverables directory at ${deliverablesDir}`);
+    throw new Error(`Cannot create deliverables directory at ${targetSubdir}`);
   }
 
   writeFileSync(filepath, content, 'utf8');
@@ -123,10 +124,14 @@ function main(): void {
   if (args.content) {
     content = args.content;
   } else if (args.filePath) {
-    // Path traversal protection: must resolve inside cwd
+    // Path traversal protection: the resolved path must stay within cwd.
+    // Compare via path.relative so the check is separator-correct on every
+    // platform and never false-matches a sibling dir by string prefix.
     const cwd = process.cwd();
     const resolved = resolve(cwd, args.filePath);
-    if (!resolved.startsWith(`${cwd}/`) && resolved !== cwd) {
+    const relativePath = relative(cwd, resolved);
+    const escapesCwd = relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath);
+    if (escapesCwd) {
       console.log(
         JSON.stringify({ status: 'error', message: `Path traversal detected: ${args.filePath}`, retryable: false }),
       );


### PR DESCRIPTION
## Summary

A small batch of correctness/UX fixes found while reading through the CLI and worker code.

### CLI / UX

1. **Invalid command in config error** — the invalid-config error path told users to run `shn setup`, but the published binary is `shannon` (see `apps/cli/package.json` `bin`); there is no `shn` command. It now matches the sibling parse-error message in the same file (`npx @keygraph/shannon setup`).

2. **Splash ignored `NO_COLOR` / non-TTY** — `displaySplash` always emitted raw ANSI color codes, so escape sequences leaked into piped/redirected output and the [`NO_COLOR`](https://no-color.org) convention was ignored. Color is now gated behind a `shouldUseColor()` check (`NO_COLOR` disables, `FORCE_COLOR` forces, otherwise TTY-only). The box-drawing glyphs are unaffected, so the logo still renders in monochrome.

### Worker

3. **Broken path-traversal guard** in `save-deliverable` — the check used `resolved.startsWith(`${cwd}/`)` with a hardcoded `/` separator and a brittle string-prefix match. On Windows `resolve()` returns backslash paths, so legitimate paths were rejected as traversal attempts, and the prefix match could false-trigger on sibling directories. Replaced with a `path.relative()`-based check (separator-correct, no prefix aliasing).

4. **Duplicated path logic** — the same script rebuilt the deliverables directory inline with the same `subdir.split('/')` logic and a hardcoded default string that already lives in `deliverablesDir()` / `DEFAULT_DELIVERABLES_SUBDIR` in `paths.ts` (used by every other call site). It now reuses the shared helper, which also removes a local variable that shadowed it.

## Testing

- `tsc --noEmit` passes for both packages (`turbo run check`).
- `biome lint` is clean on all changed files.
- The new traversal logic was verified against inside / parent / absolute path cases.