### PR TITLE
fix(worker): stop resume from deleting untracked completed deliverables (#370)

### DIFF
--- a/apps/worker/src/temporal/activities.ts
+++ b/apps/worker/src/temporal/activities.ts
@@ -967,9 +967,18 @@ export async function restoreGitCheckpoint(
     deliverablesPath,
     'reset deliverables to checkpoint',
   );
-  await executeGitCommandWithRetry(['git', 'clean', '-fd'], deliverablesPath, 'clean untracked deliverables');
 
-  // Explicitly delete partial deliverables for incomplete agents
+  // Delete only the partial deliverables for incomplete agents.
+  //
+  // NOTE: We intentionally avoid `git clean -fd` here. A completed agent's
+  // deliverable can exist on disk while being untracked in the deliverables git
+  // (e.g. written by the agent after its checkpoint commit was created).
+  // `git reset --hard` leaves untracked files in place, but `git clean -fd`
+  // would delete them — wiping a finished agent's analysis even though
+  // session.json marks it successful. checkExploitationQueue would then fail on
+  // every retry (queue file present, analysis deliverable gone). Targeted
+  // per-agent cleanup removes exactly the work that must re-run and nothing a
+  // completed agent already produced.
   for (const agentName of incompleteAgents) {
     const deliverableFilename = AGENTS[agentName].deliverableFilename;
     const deliverablePath = path.join(deliverablesPath, deliverableFilename);


### PR DESCRIPTION
Fixes #370.

## Problem

When a scan is stopped mid-run and resumed, `restoreGitCheckpoint` runs:

```
git reset --hard <checkpoint>
git clean -fd
```

`git clean -fd` deletes **all** untracked files in the deliverables directory. If a completed vuln agent's analysis deliverable (e.g. `auth_analysis_deliverable.md`) was written to disk but never committed to the deliverables git, it is untracked — so it gets wiped, even though `session.json` marks that agent `success`.

The result, as reported in #370:

- `loadResumeState` saw the file on disk and marked the agent complete (skipped on resume).
- `checkExploitationQueue` then can't find the deliverable and fails on every retry with `Analysis incomplete: Queue exists but deliverable file missing`.
- The error is `retryable`, so the worker spins indefinitely at the 30-minute `PRODUCTION_RETRY` cap and the scan never completes.

## Fix

Remove the blanket `git clean -fd` and rely on the cleanup that already exists.

- `git reset --hard <checkpoint>` already restores every tracked/committed deliverable to checkpoint state, and **leaves untracked files in place** — so a completed agent's untracked deliverable now survives the resume.
- The function already deletes each incomplete agent's deliverable explicitly. The caller passes `incompleteAgents = ALL_AGENTS` minus `completedAgents` (`workflows.ts`), so this targeted loop covers exactly the partial work that must be re-run.

`git clean -fd` therefore added nothing the targeted loop didn't already do — only the destructive side effect of removing completed agents' untracked deliverables. This corresponds to "Suggested Fix #2" in the issue. (The issue's complementary "fix #1" — committing every deliverable into the checkpoint — touches the checkpoint-staging architecture and is left as a follow-up.)

## Testing

- `tsc --noEmit` passes for both packages (`turbo run check`).
- `biome lint` is clean on the changed file.

Note: I couldn't reproduce the full multi-hour scan end-to-end locally, so this is verified by static analysis of the resume path (`loadResumeState` → `restoreGitCheckpoint` → `checkExploitationQueue`) rather than a live resume run.