### PR TITLE
fix(workflow): gracefully skip a failed/refused exploit agent instead of aborting the run

### DIFF
--- a/apps/worker/src/temporal/shared.ts
+++ b/apps/worker/src/temporal/shared.ts
@@ -52,6 +52,9 @@ export interface PipelineState {
   currentPhase: string | null;
   currentAgent: string | null;
   completedAgents: string[];
+  // Exploit agents that failed and were gracefully skipped (e.g. Claude content-policy
+  // refusal). Their vuln analysis findings are preserved; the run still reaches Reporting.
+  skippedExploits: string[];
   failedAgent: string | null;
   error: string | null;
   errorCode?: ErrorCode;

--- a/apps/worker/src/temporal/workflows.ts
+++ b/apps/worker/src/temporal/workflows.ts
@@ -20,7 +20,8 @@
  * - Automatic retry with backoff for transient/billing errors
  * - Non-retryable classification for permanent errors
  * - Audit correlation via workflowId
- * - Graceful failure handling: pipelines continue if one fails
+ * - Graceful failure handling: a failed or refused exploit agent is skipped so sibling
+ *   pipelines and the Reporting phase still run; only analysis failures abort the run
  */
 
 import {
@@ -60,6 +61,27 @@ function computeExpectedAgents(vulnClasses: readonly VulnClass[], exploit: boole
   }
   expected.push('report');
   return expected;
+}
+
+/** Substrings that mark a Claude content-policy refusal surfaced through the agent SDK. */
+const CONTENT_POLICY_MARKERS = ['usage policy', 'unable to respond'] as const;
+
+/**
+ * Detect whether an exploit-agent failure is a Claude content-policy refusal.
+ * Walks the error's `.cause` chain (Temporal wraps ApplicationFailure in ActivityFailure)
+ * and matches known refusal phrasing case-insensitively. Duck-typed because workflow code
+ * cannot import @temporalio/activity error types.
+ */
+function isContentPolicyRefusal(error: unknown): boolean {
+  let current: unknown = error;
+  while (current instanceof Error) {
+    const message = current.message.toLowerCase();
+    if (CONTENT_POLICY_MARKERS.some((marker) => message.includes(marker))) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 // Retry configuration for production (long intervals for billing recovery)
@@ -203,6 +225,7 @@ export async function pentestPipeline(input: PipelineInput): Promise<PipelineSta
     currentPhase: null,
     currentAgent: null,
     completedAgents: [],
+    skippedExploits: [],
     failedAgent: null,
     error: null,
     startTime: Date.now(),
@@ -501,15 +524,36 @@ export async function pentestPipeline(input: PipelineInput): Promise<PipelineSta
 
       // 3. Previously-completed exploits are preserved regardless of mode; new exploits gated by mode.
       let exploitMetrics: AgentMetrics | null = null;
+      let exploitError: string | null = null;
       if (shouldSkip(exploitAgentName)) {
         log.info(`Skipping ${exploitAgentName} (already complete)`);
         state.completedAgents.push(exploitAgentName);
       } else if (decision.shouldExploit && exploit) {
-        exploitMetrics = await runExploitAgent();
-        state.agentMetrics[exploitAgentName] = exploitMetrics;
-        state.completedAgents.push(exploitAgentName);
-        if (input.checkpointsEnabled) {
-          await a.saveCheckpoint(activityInput, exploitAgentName, 'exploitation', state);
+        // Isolate exploit-agent failures. A single agent refusing (Claude content policy)
+        // or erroring must NOT reject this pipeline: a rejection propagates through
+        // runWithConcurrencyLimit to the top-level catch, aborting sibling pipelines and
+        // skipping Reporting. The vuln analysis findings recorded in step 1 are the durable
+        // value and are preserved on skip. Analysis-agent failures are intentionally not
+        // caught here — they still propagate and fail the run.
+        try {
+          exploitMetrics = await runExploitAgent();
+          state.agentMetrics[exploitAgentName] = exploitMetrics;
+          state.completedAgents.push(exploitAgentName);
+          if (input.checkpointsEnabled) {
+            await a.saveCheckpoint(activityInput, exploitAgentName, 'exploitation', state);
+          }
+        } catch (error) {
+          // Temporal cancellation must always propagate — it is not an exploit failure.
+          if (isCancellation(error)) {
+            throw error;
+          }
+          const reason = isContentPolicyRefusal(error) ? 'content-policy refusal' : 'execution error';
+          const detail = error instanceof Error ? error.message : String(error);
+          exploitError = `${exploitAgentName} skipped (${reason}): ${detail.replaceAll('|', '/')}`;
+          state.skippedExploits.push(exploitAgentName);
+          log.warn(
+            `Exploit agent ${exploitAgentName} failed (${reason}); skipping exploitation for ${vulnType} and continuing. Analysis findings preserved.`,
+          );
         }
       }
 
@@ -521,7 +565,7 @@ export async function pentestPipeline(input: PipelineInput): Promise<PipelineSta
           shouldExploit: decision.shouldExploit,
           vulnerabilityCount: decision.vulnerabilityCount,
         },
-        error: null,
+        error: exploitError,
       };
     }
 


### PR DESCRIPTION
### What

Isolate exploit-agent failures inside `runVulnExploitPipeline` so a single failed or **content-policy–refused** exploit agent no longer rejects its pipeline. Today that rejection propagates through `runWithConcurrencyLimit` to the workflow's top-level `catch`, which marks the whole run `failed` — **aborting sibling pipelines still in flight and skipping the Reporting phase entirely**. One refused exploit therefore discards the completed vulnerability-analysis deliverables *and* the report.

This wraps the exploit-agent call in `try/catch`:

- Temporal cancellation is re-thrown unchanged (it is not an exploit failure).
- Any other error is classified as a content-policy refusal (`usage policy` / `unable to respond`) or a generic execution error, recorded in a new `state.skippedExploits[]` and in the returned `VulnExploitPipelineResult.error`, logged via `log.warn`, and the pipeline **returns normally**.
- The already-recorded vulnerability-analysis findings are preserved.
- **Analysis-agent** failures are intentionally left uncaught, so genuinely broken runs still fail loudly.

Adds `skippedExploits: string[]` to `PipelineState` (`shared.ts`).

### Why

The workflow header already documents the intended behavior — *"Graceful failure handling: pipelines continue if one fails"* — and `aggregatePipelineResults` is built to **log** failed pipelines rather than abort. A rejecting exploit agent short-circuited that design. This change makes the code match its own contract, keeping the durable, expensive output (vulnerability analysis + the report) even when one exploitation step can't proceed.

The escape hatch that exists today — re-running with `exploit: false` — does **not** work on resume: `vuln_classes`/`exploit` scope is locked into `session.json` on the first run and validated by `persistOrValidateRunScope`, so an operator who hits a refusal mid-run cannot flip scope to salvage a report.

### How it was hit

During an authorized white-box engagement, an authenticated exploitation agent hit a hard Claude content-policy refusal:

```
Claude Code is unable to respond to this request, which appears to violate our Usage Policy
```

Because that refusal is not classified as terminal, under the `subscription` retry preset the same agent was re-attempted repeatedly (observed ~8× across resumes) with long backoff, and the eventual failure took down sibling pipelines and the report. This PR fixes the **abort-cascade** half of that problem, which is valuable regardless of how the refusal itself is classified.

There is a complementary follow-up I can send separately: classifying content-policy refusals as **non-retryable** in `error-handling.ts` so the agent fast-fails after one attempt instead of retrying for hours. That is orthogonal to this change — this PR makes the pipeline resilient to *any* exploit-agent failure; the follow-up just makes the refusal case fail faster. Happy to open it as an issue/PR if you're interested.

### Scope / safety

- Only exploit-agent failures are swallowed; analysis-agent failures and Temporal cancellation still propagate.
- The skip is **observable**: `state.skippedExploits` (queryable via `getProgress`), the pipeline result's `error`, and a `log.warn`.
- No behavior change on the happy path or on analysis failures.

### Honest testing note

The failure mode that motivated this (the refusal retry-storm) is real and was observed in the engagement. In a later verification run on a patched build, the specific graceful-skip `catch` branch was **not** exercised, because the refused agent *eventually succeeded on a retry* rather than terminally refusing — so that run reached Reporting because the agent completed, not because it was skipped. This change is the safety net for the *terminal*-refusal case (which the earlier run showed is reachable). I couldn't find a merged test harness in `apps/worker` yet (I see Vitest proposed in #366); I'm glad to add a unit test for `isContentPolicyRefusal` + the skip branch if you'd like, or to bootstrap a minimal Vitest setup in this PR.

### Checklist

- [x] `biome check .` passes on the changed files
- [x] `tsc --noEmit` (worker) passes
- [x] Conventional-commit title; no Claude attribution in the commit trailer
- [x] No secrets / target-specific data in the diff (generic control-flow only)
