### PR TITLE
fix: correct error-retry classification and resume checkpoint safety

### DIFF
--- a/apps/cli/src/commands/start.ts
+++ b/apps/cli/src/commands/start.ts
@@ -40,12 +40,28 @@ function migrateLegacyWorkspaceLayout(workspacePath: string): void {
     return;
   }
 
-  fs.mkdirSync(internalPath, { recursive: true });
-  for (const entry of fs.readdirSync(workspacePath)) {
-    if (entry === INTERNAL_DIR) {
-      continue;
+  // Stage the moves in a sibling temp dir and rename it into place as the one final,
+  // atomic step. internalPath must never come into existence until every entry has been
+  // moved — otherwise a failure partway through the loop would leave it existing, and the
+  // existsSync guard above would then treat migration as already done and permanently
+  // skip it on every future run, stranding whatever hadn't been moved yet.
+  const stagingPath = `${internalPath}.migrating-${process.pid}`;
+  fs.rmSync(stagingPath, { recursive: true, force: true });
+  fs.mkdirSync(stagingPath, { recursive: true });
+  try {
+    for (const entry of fs.readdirSync(workspacePath)) {
+      if (entry === INTERNAL_DIR || entry.startsWith(`${INTERNAL_DIR}.migrating-`)) {
+        continue;
+      }
+      fs.renameSync(path.join(workspacePath, entry), path.join(stagingPath, entry));
     }
-    fs.renameSync(path.join(workspacePath, entry), path.join(internalPath, entry));
+    fs.renameSync(stagingPath, internalPath);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`ERROR: Failed to migrate workspace to ${INTERNAL_DIR}/ layout: ${detail}`);
+    console.error(`  Partially-migrated files are staged at: ${stagingPath}`);
+    console.error('  Resolve the underlying issue and retry, or restore the workspace from backup.');
+    process.exit(1);
   }
   console.log(`Migrated workspace to ${INTERNAL_DIR}/ layout: ${workspacePath}`);
 }

--- a/apps/cli/src/config/writer.ts
+++ b/apps/cli/src/config/writer.ts
@@ -25,4 +25,8 @@ export function saveConfig(config: ShannonConfig): void {
 
   const content = stringify(config);
   fs.writeFileSync(configPath, content, { mode: 0o600 });
+  // writeFileSync's `mode` only applies when creating the file — Node ignores it when
+  // overwriting an existing one, so re-running setup wouldn't tighten permissions that
+  // had been loosened. chmod explicitly to guarantee 0o600 either way.
+  fs.chmodSync(configPath, 0o600);
 }

--- a/apps/cli/src/docker.ts
+++ b/apps/cli/src/docker.ts
@@ -217,11 +217,13 @@ function forwardEtcHostsFlags(): string[] {
     if (!ip || names.length === 0) continue;
     if (shouldSkipHostsIp(ip)) continue;
 
+    // Docker's --add-host parser splits on the first colon only, then validates the
+    // remainder as a bare IP literal — bracketing an IPv6 address (valid in URLs, invalid
+    // here) makes Docker reject the whole flag.
     const targetIp = isLoopbackIp(ip) ? 'host-gateway' : ip;
-    const formattedIp = targetIp.includes(':') ? `[${targetIp}]` : targetIp;
     for (const name of names) {
       if (shouldSkipHostsName(name, hostname)) continue;
-      flags.push('--add-host', `${name}:${formattedIp}`);
+      flags.push('--add-host', `${name}:${targetIp}`);
     }
   }
 

--- a/apps/cli/src/paths.ts
+++ b/apps/cli/src/paths.ts
@@ -54,9 +54,13 @@ export function resolveRepo(repoArg: string): MountPair {
   let hostPath: string;
 
   if (isLocal() && !repoArg.startsWith('/') && !repoArg.startsWith('.')) {
-    // Bare name — check ./repos/<name> for backward compatibility
-    const barePath = path.resolve('repos', repoArg);
-    if (fs.existsSync(barePath)) {
+    // Bare name — check ./repos/<name> for backward compatibility. Reject any name
+    // (e.g. containing ../) that would resolve outside ./repos/ — otherwise a bare
+    // name could mount an arbitrary host directory into the worker container.
+    const reposRoot = path.resolve('repos');
+    const barePath = path.resolve(reposRoot, repoArg);
+    const withinReposRoot = barePath === reposRoot || barePath.startsWith(`${reposRoot}${path.sep}`);
+    if (withinReposRoot && fs.existsSync(barePath)) {
       hostPath = barePath;
     } else {
       console.error(`ERROR: Repository not found at ./repos/${repoArg}`);

--- a/apps/worker/configs/config-schema.json
+++ b/apps/worker/configs/config-schema.json
@@ -208,7 +208,8 @@
     { "required": ["vuln_classes"] },
     { "required": ["exploit"] },
     { "required": ["report"] },
-    { "required": ["rules_of_engagement"] }
+    { "required": ["rules_of_engagement"] },
+    { "required": ["pipeline"] }
   ],
   "additionalProperties": false,
   "$defs": {

--- a/apps/worker/prompts/shared/login-instructions.txt
+++ b/apps/worker/prompts/shared/login-instructions.txt
@@ -37,6 +37,22 @@ Execute the login flow based on the login_type specified in the configuration:
 4. Ensure all consent and authorization steps are explicitly handled
 <!-- END:SSO -->
 
+<!-- BEGIN:API -->
+**API-based authentication (no browser login form):**
+1. If login_flow steps are provided, execute them sequentially against login_url (e.g. via `curl` through the `bash` tool), replacing $username, $password, and $totp with the credential placeholders below.
+2. If no login_flow is provided, authenticate directly: send the username/password credentials to login_url using the target's documented request shape (commonly a POST with a JSON or form-encoded body), and capture the returned token, session cookie, or bearer credential from the response.
+3. If the target's session is cookie-based, set the captured cookie in the Playwright browser context so subsequent browser-driven testing is authenticated.
+4. If the target uses a bearer/API token instead, include it as an `Authorization` header on subsequent API requests made via the `bash` tool for the remainder of the assessment.
+<!-- END:API -->
+
+<!-- BEGIN:BASIC -->
+**HTTP Basic authentication:**
+1. Navigate to the specified login_url using Playwright.
+2. If the browser presents a native Basic Auth prompt, enter the username and password credentials and submit.
+3. If no prompt appears, the target likely expects credentials embedded in the URL or an `Authorization: Basic` header — retry navigation using `https://$username:$password@<host><path>`, or verify credentials with `curl -u $username:$password` via the `bash` tool.
+4. Basic Auth credentials are typically cached per-origin by the browser for the remainder of the session — confirm subsequent navigation stays authenticated without re-prompting.
+<!-- END:BASIC -->
+
 <!-- BEGIN:VERIFICATION -->
 </authentication_execution>
 

--- a/apps/worker/src/ai/pi/pi-executor.ts
+++ b/apps/worker/src/ai/pi/pi-executor.ts
@@ -314,15 +314,20 @@ export async function runPiPrompt(
             progress.stop();
             outputLines(formatAssistantOutput(text, execContext, turnCount, description));
             progress.start();
-            const billing = classifyErrorText(text);
-            if (billing) pendingError = billing;
           }
+          // Billing/session-limit text matching only applies to turns the harness itself
+          // flagged as errors — legitimate report prose (e.g. "no usage limit is enforced")
+          // must never be misread as a real billing error.
           if (msg.role === 'assistant' && msg.stopReason === 'error') {
             apiErrorDetected = true;
             pendingError =
               pendingError ??
-              classifyErrorText(msg.errorMessage ?? '') ??
-              new PentestError(`Agent error: ${(msg.errorMessage ?? 'unknown').slice(0, 200)}`, 'unknown', true);
+              classifyErrorText(msg.errorMessage ?? text) ??
+              new PentestError(
+                `Agent error: ${(msg.errorMessage ?? text ?? 'unknown').slice(0, 200)}`,
+                'unknown',
+                true,
+              );
           }
           break;
         }
@@ -397,22 +402,25 @@ export async function runPiPrompt(
       ...(structuredOutput !== undefined && { structuredOutput }),
     };
   } catch (error) {
-    // 10. Handle errors — log, write error file, return failure
+    // 10. Handle errors — log, write error file, return failure. A PentestError already
+    //     carries an author-classified code/retryable (e.g. billing text, session limit) —
+    //     trust those instead of re-deriving from generic message patterns.
     const duration = timer.stop();
     const err = error as Error & { code?: string; status?: number };
+    const retryable = err instanceof PentestError ? err.retryable : isRetryableError(err);
     await auditLogger.logError(err, duration, turnCount);
     progress.stop();
-    outputLines(formatErrorOutput(err, execContext, description, duration, sourceDir, isRetryableError(err)));
+    outputLines(formatErrorOutput(err, execContext, description, duration, sourceDir, retryable));
     await writeErrorLog(err, sourceDir, fullPrompt, duration);
 
     return {
       error: err.message,
-      errorType: err.constructor.name,
+      errorType: err instanceof PentestError && err.code ? err.code : err.constructor.name,
       prompt: `${fullPrompt.slice(0, 100)}...`,
       success: false,
       duration,
       cost: 0,
-      retryable: isRetryableError(err),
+      retryable,
     };
   }
 }

--- a/apps/worker/src/ai/pi/task-tool.ts
+++ b/apps/worker/src/ai/pi/task-tool.ts
@@ -17,7 +17,7 @@
  */
 
 import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
-import { type AssistantMessage, type Model, Type } from '@earendil-works/pi-ai';
+import { type Api, type AssistantMessage, type Model, Type } from '@earendil-works/pi-ai';
 import {
   type AuthStorage,
   createAgentSession,
@@ -32,8 +32,7 @@ import {
 
 export interface TaskToolContext {
   cwd: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  model: Model<any>;
+  model: Model<Api>;
   thinkingLevel?: ThinkingLevel;
   authStorage: AuthStorage;
   /** Explicit model registry for sub-session resolution. Omit to inherit the parent's default. */

--- a/apps/worker/src/audit/audit-session.ts
+++ b/apps/worker/src/audit/audit-session.ts
@@ -85,8 +85,16 @@ export class AuditSession {
     // Create directory structure
     await initializeAuditStructure(this.sessionMetadata);
 
-    // Initialize metrics tracker (loads or creates session.json)
-    await this.metricsTracker.initialize(workflowId);
+    // Initialize metrics tracker (loads or creates session.json). Mutex-protected
+    // like every other session.json mutator — without it, two concurrently-
+    // initializing AuditSessions racing the "doesn't exist yet" create path could
+    // each write their own initial session.json, the second clobbering the first.
+    const unlock = await sessionMutex.lock(this.sessionId);
+    try {
+      await this.metricsTracker.initialize(workflowId);
+    } finally {
+      unlock();
+    }
 
     // Initialize workflow logger with actual Temporal workflow ID
     await this.workflowLogger.initialize(workflowId);

--- a/apps/worker/src/audit/audit-session.ts
+++ b/apps/worker/src/audit/audit-session.ts
@@ -19,7 +19,12 @@ import { formatTimestamp } from '../utils/formatting.js';
 import { AgentLogger } from './logger.js';
 import { MetricsTracker } from './metrics-tracker.js';
 import { initializeAuditStructure, type SessionMetadata } from './utils.js';
-import { type AgentLogDetails, WorkflowLogger, type WorkflowSummary } from './workflow-logger.js';
+import {
+  type AgentLogDetails,
+  getOrCreateWorkflowLogger,
+  type WorkflowLogger,
+  type WorkflowSummary,
+} from './workflow-logger.js';
 
 // Global mutex instance
 const sessionMutex = new SessionMutex();
@@ -60,9 +65,10 @@ export class AuditSession {
       );
     }
 
-    // Components
+    // Components. The workflow logger is shared (and its log stream kept open) across
+    // every AuditSession instance for this session — see getOrCreateWorkflowLogger.
     this.metricsTracker = new MetricsTracker(sessionMetadata);
-    this.workflowLogger = new WorkflowLogger(sessionMetadata);
+    this.workflowLogger = getOrCreateWorkflowLogger(sessionMetadata);
   }
 
   /**

--- a/apps/worker/src/audit/metrics-tracker.ts
+++ b/apps/worker/src/audit/metrics-tracker.ts
@@ -292,32 +292,43 @@ export class MetricsTracker {
   }
 
   /**
+   * Elapsed time for an agent regardless of outcome. `final_duration_ms` is only set
+   * on success, so a failed or still-retrying agent's real elapsed time is the sum of
+   * its own attempts' durations instead.
+   */
+  private static effectiveDuration(data: AgentAuditMetrics): number {
+    return data.status === 'success'
+      ? data.final_duration_ms
+      : data.attempts.reduce((sum, a) => sum + a.duration_ms, 0);
+  }
+
+  /**
    * Recalculate aggregations (total duration, total cost, phases)
    */
   private recalculateAggregations(): void {
     if (!this.data) return;
 
-    const agents = this.data.metrics.agents;
+    const allAgents = Object.entries(this.data.metrics.agents);
 
-    // Only count successful agents
-    const successfulAgents = Object.entries(agents).filter(([, data]) => data.status === 'success');
-
-    // Calculate total duration and cost
-    const totalDuration = successfulAgents.reduce((sum, [, data]) => sum + data.final_duration_ms, 0);
-
-    const totalCost = successfulAgents.reduce((sum, [, data]) => sum + data.total_cost_usd, 0);
+    // Every agent's total_cost_usd already sums cost across all its attempts —
+    // success and failure alike, since a retried attempt still burns real, billed
+    // spend. Roll that into the session total regardless of the agent's final
+    // status, or a permanently-failed agent's spend silently disappears from the
+    // cumulative cost surfaced to the user.
+    const totalDuration = allAgents.reduce((sum, [, data]) => sum + MetricsTracker.effectiveDuration(data), 0);
+    const totalCost = allAgents.reduce((sum, [, data]) => sum + data.total_cost_usd, 0);
 
     this.data.metrics.total_duration_ms = totalDuration;
     this.data.metrics.total_cost_usd = totalCost;
 
     // Calculate phase-level metrics
-    this.data.metrics.phases = this.calculatePhaseMetrics(successfulAgents);
+    this.data.metrics.phases = this.calculatePhaseMetrics(allAgents);
   }
 
   /**
    * Calculate phase-level metrics
    */
-  private calculatePhaseMetrics(successfulAgents: Array<[string, AgentAuditMetrics]>): Record<string, PhaseMetrics> {
+  private calculatePhaseMetrics(allAgents: Array<[string, AgentAuditMetrics]>): Record<string, PhaseMetrics> {
     const phases: Record<PhaseName, AgentAuditMetrics[]> = {
       'pre-recon': [],
       recon: [],
@@ -327,7 +338,7 @@ export class MetricsTracker {
     };
 
     // Group agents by phase using imported AGENT_PHASE_MAP
-    for (const [agentName, agentData] of successfulAgents) {
+    for (const [agentName, agentData] of allAgents) {
       const phase = AGENT_PHASE_MAP[agentName as AgentName];
       if (phase) {
         phases[phase].push(agentData);
@@ -342,7 +353,7 @@ export class MetricsTracker {
     for (const [phaseName, agentList] of Object.entries(phases)) {
       if (agentList.length === 0) continue;
 
-      const phaseDuration = agentList.reduce((sum, agent) => sum + agent.final_duration_ms, 0);
+      const phaseDuration = agentList.reduce((sum, agent) => sum + MetricsTracker.effectiveDuration(agent), 0);
       const phaseCost = agentList.reduce((sum, agent) => sum + agent.total_cost_usd, 0);
 
       phaseMetrics[phaseName] = {

--- a/apps/worker/src/audit/workflow-logger.ts
+++ b/apps/worker/src/audit/workflow-logger.ts
@@ -386,3 +386,29 @@ export class WorkflowLogger {
     return this.logStream.close();
   }
 }
+
+// Every activity in a workflow constructs its own AuditSession (required for per-agent
+// instance state — see audit-session.ts), which would otherwise open a brand new
+// WriteStream onto the same workflow.log on every single activity call and never close
+// it. WorkflowLogger itself carries no per-agent state, so it's safe to share one
+// instance — and its one open stream — per session across all of a workflow's activities.
+const workflowLoggers = new Map<string, WorkflowLogger>();
+
+/** Reuse the cached WorkflowLogger (and its open log stream) for this session, if any. */
+export function getOrCreateWorkflowLogger(sessionMetadata: SessionMetadata): WorkflowLogger {
+  const existing = workflowLoggers.get(sessionMetadata.id);
+  if (existing) return existing;
+
+  const logger = new WorkflowLogger(sessionMetadata);
+  workflowLoggers.set(sessionMetadata.id, logger);
+  return logger;
+}
+
+/** Close and evict the cached WorkflowLogger — call once the workflow has finished
+ * writing to workflow.log (logWorkflowComplete), releasing its file descriptor. */
+export async function closeWorkflowLogger(sessionId: string): Promise<void> {
+  const logger = workflowLoggers.get(sessionId);
+  if (!logger) return;
+  workflowLoggers.delete(sessionId);
+  await logger.close();
+}

--- a/apps/worker/src/config-parser.ts
+++ b/apps/worker/src/config-parser.ts
@@ -334,6 +334,16 @@ function checkDeprecatedFields(config: Config): void {
   checkRules(rules?.avoid, 'avoid');
   checkRules(rules?.focus, 'focus');
 
+  // The top-level 'login' block predates 'authentication' and is never read by
+  // distributeConfig — accepting it silently would let a scan run unauthenticated
+  // while the user believes credentials are configured. Fail loudly instead.
+  if (raw.login !== undefined) {
+    messages.push(
+      "'login' has been replaced by 'authentication' and is no longer read — migrate its contents to the " +
+        "'authentication' section, or the scan will run unauthenticated.",
+    );
+  }
+
   if (messages.length > 0) {
     throw new PentestError(
       `Configuration uses deprecated fields. Please update:\n  - ${messages.join('\n  - ')}`,

--- a/apps/worker/src/config-parser.ts
+++ b/apps/worker/src/config-parser.ts
@@ -400,7 +400,8 @@ const validateConfig = (config: Config): void => {
     !!config.vuln_classes ||
     config.exploit !== undefined ||
     !!config.report ||
-    !!config.rules_of_engagement;
+    !!config.rules_of_engagement ||
+    !!config.pipeline;
   if (!hasAnySteering) {
     console.warn('⚠️  Configuration file contains no steering fields. The pentest will run with all defaults.');
   } else if (config.rules && !config.rules.avoid && !config.rules.focus) {
@@ -455,6 +456,21 @@ const performSecurityValidation = (config: Config): void => {
           }
         }
       });
+    }
+
+    // Rendered into the same login prompt templates as login_url/credentials/login_flow above.
+    if (auth.success_condition?.value) {
+      for (const pattern of DANGEROUS_PATTERNS) {
+        if (pattern.test(auth.success_condition.value)) {
+          throw new PentestError(
+            `authentication.success_condition.value contains potentially dangerous pattern: ${pattern.source}`,
+            'config',
+            false,
+            { field: 'success_condition.value', pattern: pattern.source },
+            ErrorCode.CONFIG_VALIDATION_FAILED,
+          );
+        }
+      }
     }
   }
 
@@ -631,10 +647,16 @@ const validateRuleTypeSpecific = (rule: Rule, ruleType: string, index: number): 
   }
 };
 
+// Matches the normalization sanitizeRule applies later, so a duplicate/conflict
+// hiding behind incidental whitespace or type casing differences (e.g. "/admin "
+// vs "/admin") is caught here instead of silently resolving to the same rule
+// after sanitization.
+const ruleKey = (rule: Rule): string => `${rule.type.trim().toLowerCase()}:${rule.value.trim()}`;
+
 const checkForDuplicates = (rules: Rule[], ruleType: string): void => {
   const seen = new Set<string>();
   rules.forEach((rule, index) => {
-    const key = `${rule.type}:${rule.value}`;
+    const key = ruleKey(rule);
     if (seen.has(key)) {
       throw new PentestError(
         `Duplicate rule found in rules.${ruleType}[${index}]: ${rule.type} '${rule.value}'`,
@@ -649,10 +671,10 @@ const checkForDuplicates = (rules: Rule[], ruleType: string): void => {
 };
 
 const checkForConflicts = (avoidRules: Rule[] = [], focusRules: Rule[] = []): void => {
-  const avoidSet = new Set(avoidRules.map((rule) => `${rule.type}:${rule.value}`));
+  const avoidSet = new Set(avoidRules.map(ruleKey));
 
   focusRules.forEach((rule, index) => {
-    const key = `${rule.type}:${rule.value}`;
+    const key = ruleKey(rule);
     if (avoidSet.has(key)) {
       throw new PentestError(
         `Conflicting rule found: rules.focus[${index}] '${rule.value}' also exists in rules.avoid`,

--- a/apps/worker/src/config-parser.ts
+++ b/apps/worker/src/config-parser.ts
@@ -44,10 +44,11 @@ try {
 
 const DANGEROUS_PATTERNS: RegExp[] = [
   /\.\.\//, // Path traversal
-  /[<>]/, // HTML/XML injection
-  /javascript:/i, // JavaScript URLs
-  /data:/i, // Data URLs
-  /file:/i, // File URLs
+  /<\/?[a-zA-Z!]/, // HTML/XML tags (e.g. <script, </div, <!--) — not a bare '<'/'>', which
+  // also rejected benign text like "count > 5"
+  /\bjavascript:/i, // JavaScript URL scheme
+  /\bdata:/i, // Data URL scheme — \b avoids matching inside words like "metadata:"
+  /\bfile:/i, // File URL scheme — \b avoids matching inside words like "profile:"
 ];
 
 /**

--- a/apps/worker/src/scripts/save-deliverable.ts
+++ b/apps/worker/src/scripts/save-deliverable.ts
@@ -15,9 +15,10 @@
  *   node save-deliverable.js --type INJECTION_ANALYSIS --file-path deliverables/injection_analysis_deliverable.md
  */
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { DELIVERABLE_FILENAMES, type DeliverableType } from '../types/deliverables.js';
+import { atomicWrite } from '../utils/file-io.js';
 
 // === Help ===
 
@@ -76,7 +77,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 // === File Operations ===
 
-function saveDeliverableFile(targetDir: string, filename: string, content: string): string {
+async function saveDeliverableFile(targetDir: string, filename: string, content: string): Promise<string> {
   const subdir = process.env.SHANNON_DELIVERABLES_SUBDIR || '.shannon/deliverables';
   const deliverablesDir = join(targetDir, ...subdir.split('/'));
   const filepath = join(deliverablesDir, filename);
@@ -87,13 +88,16 @@ function saveDeliverableFile(targetDir: string, filename: string, content: strin
     throw new Error(`Cannot create deliverables directory at ${deliverablesDir}`);
   }
 
-  writeFileSync(filepath, content, 'utf8');
+  // Atomic write (temp file + rename) — same crash-safety guarantee used
+  // everywhere else deliverables/state get written, so a crash mid-write can't
+  // leave a truncated deliverable file on disk.
+  await atomicWrite(filepath, content);
   return filepath;
 }
 
 // === Main ===
 
-function main(): void {
+async function main(): Promise<void> {
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
     printHelp();
     return;
@@ -154,7 +158,7 @@ function main(): void {
   // 3. Save the file
   try {
     const targetDir = process.cwd();
-    const filepath = saveDeliverableFile(targetDir, filename, content);
+    const filepath = await saveDeliverableFile(targetDir, filename, content);
     console.log(JSON.stringify({ status: 'success', filepath }));
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -163,4 +167,4 @@ function main(): void {
   }
 }
 
-main();
+await main();

--- a/apps/worker/src/services/error-handling.ts
+++ b/apps/worker/src/services/error-handling.ts
@@ -172,7 +172,20 @@ export function classifyErrorForTemporal(error: unknown): { type: string; retrya
 
   // === STRING-BASED CLASSIFICATION (Fallback for external errors) ===
   const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  const stringClassification = classifyByMessage(message);
 
+  // A PentestError without a code still carries an author-set retryable flag that is
+  // more reliable than message heuristics (e.g. queue-validation intentionally marks
+  // malformed-JSON retryable, preflight intentionally marks an unavailable model
+  // non-retryable) — honor it, keeping the message-derived type for reporting.
+  if (error instanceof PentestError) {
+    return { type: stringClassification.type, retryable: error.retryable };
+  }
+
+  return stringClassification;
+}
+
+function classifyByMessage(message: string): { type: string; retryable: boolean } {
   // === BILLING ERRORS (Retryable with long backoff) ===
   // Anthropic returns billing as 400 invalid_request_error
   // Human can add credits OR wait for spending cap to reset (5-30 min backoff)

--- a/apps/worker/src/services/exploit-renderer.ts
+++ b/apps/worker/src/services/exploit-renderer.ts
@@ -86,7 +86,7 @@ function sortBlocked(entries: readonly BlockedEntry[]): BlockedEntry[] {
 
 function capitalize(value: string): string {
   if (value.length === 0) return value;
-  return value[0]!.toUpperCase() + value.slice(1);
+  return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 function renderNumberedList(steps: readonly string[]): string {

--- a/apps/worker/src/services/findings-renderer.ts
+++ b/apps/worker/src/services/findings-renderer.ts
@@ -33,6 +33,8 @@ interface ClassConfig<T> {
   readonly noneFoundLabel: string;
   readonly queueFile: string;
   readonly findingsFile: string;
+  /** Exploit agent's evidence file — when present, it takes precedence over rendered findings. */
+  readonly evidenceFile: string;
   readonly renderEntry: (entry: T) => string;
 }
 
@@ -159,6 +161,7 @@ const CLASSES: Record<VulnClass, ClassConfig<unknown>> = {
     noneFoundLabel: 'authentication',
     queueFile: 'auth_exploitation_queue.json',
     findingsFile: 'auth_findings.md',
+    evidenceFile: 'auth_exploitation_evidence.md',
     renderEntry: (e) => renderAuthEntry(e as AuthFinding),
   },
   authz: {
@@ -166,6 +169,7 @@ const CLASSES: Record<VulnClass, ClassConfig<unknown>> = {
     noneFoundLabel: 'authorization',
     queueFile: 'authz_exploitation_queue.json',
     findingsFile: 'authz_findings.md',
+    evidenceFile: 'authz_exploitation_evidence.md',
     renderEntry: (e) => renderAuthzEntry(e as AuthzFinding),
   },
   injection: {
@@ -173,6 +177,7 @@ const CLASSES: Record<VulnClass, ClassConfig<unknown>> = {
     noneFoundLabel: 'injection',
     queueFile: 'injection_exploitation_queue.json',
     findingsFile: 'injection_findings.md',
+    evidenceFile: 'injection_exploitation_evidence.md',
     renderEntry: (e) => renderInjectionEntry(e as InjectionFinding),
   },
   xss: {
@@ -180,6 +185,7 @@ const CLASSES: Record<VulnClass, ClassConfig<unknown>> = {
     noneFoundLabel: 'XSS',
     queueFile: 'xss_exploitation_queue.json',
     findingsFile: 'xss_findings.md',
+    evidenceFile: 'xss_exploitation_evidence.md',
     renderEntry: (e) => renderXssEntry(e as XssFinding),
   },
   ssrf: {
@@ -187,6 +193,7 @@ const CLASSES: Record<VulnClass, ClassConfig<unknown>> = {
     noneFoundLabel: 'SSRF',
     queueFile: 'ssrf_exploitation_queue.json',
     findingsFile: 'ssrf_findings.md',
+    evidenceFile: 'ssrf_exploitation_evidence.md',
     renderEntry: (e) => renderSsrfEntry(e as SsrfFinding),
   },
 };
@@ -233,9 +240,12 @@ function renderClassFile(
 /**
  * Render `*_findings.md` per class from each `*_exploitation_queue.json`.
  *
- * Idempotent: skips classes whose findings file already exists, or whose queue
- * is missing (class out of scope this run). Per-class failures are logged and
- * other classes still proceed.
+ * Idempotent: skips classes whose findings file already exists, whose exploit
+ * agent already produced an evidence file (evidence takes precedence — this
+ * fills the gap only when there's no evidence, e.g. exploit:false globally, or
+ * the exploit agent failed/never ran for this one class on an exploit:true run),
+ * or whose queue is missing (class out of scope this run). Per-class failures
+ * are logged and other classes still proceed.
  */
 export async function renderFindingsFromQueues(
   sourceDir: string,
@@ -247,9 +257,14 @@ export async function renderFindingsFromQueues(
   for (const config of Object.values(CLASSES)) {
     const queuePath = path.join(dir, config.queueFile);
     const findingsPath = path.join(dir, config.findingsFile);
+    const evidencePath = path.join(dir, config.evidenceFile);
 
     if (await fs.pathExists(findingsPath)) {
       logger.info(`${config.heading}: ${config.findingsFile} already exists, skipping`);
+      continue;
+    }
+    if (await fs.pathExists(evidencePath)) {
+      logger.info(`${config.heading}: ${config.evidenceFile} already covers this class, skipping`);
       continue;
     }
     if (!(await fs.pathExists(queuePath))) {

--- a/apps/worker/src/services/findings-renderer.ts
+++ b/apps/worker/src/services/findings-renderer.ts
@@ -53,6 +53,23 @@ function formatLocation(endpoint: string | undefined, codeLocation: string | und
   return endpoint ?? codeLocation ?? '';
 }
 
+/**
+ * Every finding type carries ID + vulnerability_type as its render identity. The queue
+ * JSON is read straight off disk (not the in-memory, already-validated submit-tool
+ * payload), so a hand-edited or partially-written file can still reach this renderer —
+ * guard against silently emitting "undefined: undefined" into the customer report.
+ */
+function hasValidIdentity(entry: unknown): entry is { ID: string; vulnerability_type: string } {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const record = entry as Record<string, unknown>;
+  return (
+    typeof record.ID === 'string' &&
+    record.ID.trim() !== '' &&
+    typeof record.vulnerability_type === 'string' &&
+    record.vulnerability_type.trim() !== ''
+  );
+}
+
 function buildEntry(
   id: string,
   title: string,
@@ -176,7 +193,22 @@ const CLASSES: Record<VulnClass, ClassConfig<unknown>> = {
 
 // === Class File Assembly ===
 
-function renderClassFile(config: ClassConfig<unknown>, entries: readonly unknown[]): string {
+function renderClassFile(
+  config: ClassConfig<unknown>,
+  entries: readonly unknown[],
+  logger: ActivityLogger,
+): { markdown: string; renderedCount: number; skippedCount: number } {
+  const renderable: unknown[] = [];
+  let skippedCount = 0;
+  for (const entry of entries) {
+    if (hasValidIdentity(entry)) {
+      renderable.push(entry);
+    } else {
+      skippedCount++;
+      logger.warn(`${config.heading}: skipping malformed queue entry (missing ID or vulnerability_type)`);
+    }
+  }
+
   const sections: string[] = [];
   sections.push(`# ${config.heading} Findings`);
   sections.push('');
@@ -184,16 +216,16 @@ function renderClassFile(config: ClassConfig<unknown>, entries: readonly unknown
   sections.push('');
   sections.push('## Identified Vulnerabilities');
   sections.push('');
-  if (entries.length === 0) {
+  if (renderable.length === 0) {
     sections.push(`No ${config.noneFoundLabel} vulnerabilities were identified.`);
     sections.push('');
   } else {
-    for (const entry of entries) {
+    for (const entry of renderable) {
       sections.push(config.renderEntry(entry));
       sections.push('');
     }
   }
-  return `${sections.join('\n').trimEnd()}\n`;
+  return { markdown: `${sections.join('\n').trimEnd()}\n`, renderedCount: renderable.length, skippedCount };
 }
 
 // === Public Entry Point ===
@@ -228,9 +260,11 @@ export async function renderFindingsFromQueues(
     try {
       const doc = (await fs.readJson(queuePath)) as QueueDocument<unknown>;
       const entries = doc.vulnerabilities ?? [];
-      const markdown = renderClassFile(config, entries);
+      const { markdown, renderedCount, skippedCount } = renderClassFile(config, entries, logger);
       await fs.writeFile(findingsPath, markdown);
-      logger.info(`${config.heading}: rendered ${entries.length} finding(s) to ${config.findingsFile}`);
+      const skippedNote =
+        skippedCount > 0 ? ` (${skippedCount} malformed entr${skippedCount === 1 ? 'y' : 'ies'} skipped)` : '';
+      logger.info(`${config.heading}: rendered ${renderedCount} finding(s) to ${config.findingsFile}${skippedNote}`);
     } catch (error) {
       const err = error as Error;
       logger.warn(`${config.heading}: failed to render findings from ${config.queueFile}: ${err.message}`);

--- a/apps/worker/src/services/git-manager.ts
+++ b/apps/worker/src/services/git-manager.ts
@@ -233,9 +233,42 @@ export async function executeGitCommandWithRetry(
   );
 }
 
+// Substring git uses when `checkout -- <path>` fails because that path has no
+// entry in HEAD (never committed) — expected for files a still-running attempt
+// created fresh; nothing to restore, and `git clean` below removes them as untracked.
+const PATHSPEC_MISMATCH_PATTERN = 'did not match any file';
+
+function isPathspecMismatchError(errorMessage: string): boolean {
+  return errorMessage.toLowerCase().includes(PATHSPEC_MISMATCH_PATTERN);
+}
+
+// Discard tracked-file modifications under `paths`, restoring each back to HEAD's
+// content. Paths with no HEAD entry (never committed) are left for `git clean` to
+// remove as untracked. Scoped equivalent of `git reset --hard` for a path subset —
+// `reset --hard` itself has no path-scoping form, so it can't be used here.
+async function restoreScopedPaths(sourceDir: string, paths: readonly string[]): Promise<void> {
+  await executeGitCommandWithRetry(['git', 'reset', '--', ...paths], sourceDir, 'unstage scoped paths for rollback');
+  for (const relPath of paths) {
+    try {
+      await executeGitCommandWithRetry(
+        ['git', 'checkout', 'HEAD', '--', relPath],
+        sourceDir,
+        `restore ${relPath} for rollback`,
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (!isPathspecMismatchError(errorMessage)) {
+        throw error;
+      }
+    }
+  }
+}
+
 // Two-phase reset: hard reset (tracked files) + clean (untracked files).
-// When paths is provided, the untracked clean is scoped to those paths so a
-// failing agent's rollback can't delete a concurrent sibling agent's scratch.
+// When paths is provided, BOTH phases are scoped to those paths so a failing
+// agent's rollback can't touch a concurrent sibling agent's tracked or untracked
+// changes in the shared deliverables repo. Without paths, the reset/clean are
+// repo-wide (used only when no per-agent scope applies).
 export async function rollbackGitWorkspace(
   sourceDir: string,
   reason: string = 'retry preparation',
@@ -250,10 +283,15 @@ export async function rollbackGitWorkspace(
 
   logger.info(`Rolling back workspace for ${reason}`);
   try {
+    const scoped = paths && paths.length > 0;
     const changes = await withGitRepoLock(async () => {
       const pendingChanges = await getChangedFiles(sourceDir, 'status check for rollback');
-      await executeGitCommandWithRetry(['git', 'reset', '--hard', 'HEAD'], sourceDir, 'hard reset for rollback');
-      const cleanArgs = paths && paths.length > 0 ? ['git', 'clean', '-fd', '--', ...paths] : ['git', 'clean', '-fd'];
+      if (scoped) {
+        await restoreScopedPaths(sourceDir, paths);
+      } else {
+        await executeGitCommandWithRetry(['git', 'reset', '--hard', 'HEAD'], sourceDir, 'hard reset for rollback');
+      }
+      const cleanArgs = scoped ? ['git', 'clean', '-fd', '--', ...paths] : ['git', 'clean', '-fd'];
       await executeGitCommandWithRetry(cleanArgs, sourceDir, 'cleaning untracked files for rollback');
       return pendingChanges;
     });

--- a/apps/worker/src/services/git-manager.ts
+++ b/apps/worker/src/services/git-manager.ts
@@ -202,6 +202,15 @@ export async function executeGitCommandWithRetry(
     return withGitRepoLock(() => executeGitCommandWithRetry(commandArgs, sourceDir, description, maxRetries));
   }
 
+  const exhaustedRetriesError = (errMsg: string): PentestError =>
+    new PentestError(
+      `Git command failed after ${maxRetries} retries: ${errMsg}`,
+      'filesystem',
+      true, // Retryable - transient git lock issues
+      { maxRetries, description },
+      ErrorCode.GIT_CHECKPOINT_FAILED,
+    );
+
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       const [cmd, ...args] = commandArgs;
@@ -210,27 +219,28 @@ export async function executeGitCommandWithRetry(
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
 
-      if (isGitLockError(errMsg) && attempt < maxRetries) {
-        const delay = 2 ** (attempt - 1) * 1000;
-        // executeGitCommandWithRetry is also called outside activity context
-        // (e.g., from resume logic), so we use console.warn as a fallback here
-        console.warn(
-          `Git lock conflict during ${description} (attempt ${attempt}/${maxRetries}). Retrying in ${delay}ms...`,
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        continue;
+      if (isGitLockError(errMsg)) {
+        if (attempt < maxRetries) {
+          const delay = 2 ** (attempt - 1) * 1000;
+          // executeGitCommandWithRetry is also called outside activity context
+          // (e.g., from resume logic), so we use console.warn as a fallback here
+          console.warn(
+            `Git lock conflict during ${description} (attempt ${attempt}/${maxRetries}). Retrying in ${delay}ms...`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+        // Retries exhausted on a genuine lock conflict — surface the classified,
+        // retryable error instead of letting the raw git/zx failure propagate.
+        throw exhaustedRetriesError(errMsg);
       }
 
       throw error;
     }
   }
-  throw new PentestError(
-    `Git command failed after ${maxRetries} retries`,
-    'filesystem',
-    true, // Retryable - transient git lock issues
-    { maxRetries, description },
-    ErrorCode.GIT_CHECKPOINT_FAILED,
-  );
+  // Unreachable — every iteration above returns or throws — but required so the
+  // function's return type checks without an explicit return after the loop.
+  throw exhaustedRetriesError('retries exhausted');
 }
 
 // Substring git uses when `checkout -- <path>` fails because that path has no

--- a/apps/worker/src/services/prompt-manager.ts
+++ b/apps/worker/src/services/prompt-manager.ts
@@ -225,8 +225,23 @@ async function buildLoginInstructions(
   }
 }
 
-// Pure function: Process @include() directives
-async function processIncludes(content: string, baseDir: string): Promise<string> {
+const MAX_INCLUDE_DEPTH = 5;
+
+// Pure function: Process @include() directives, recursively — an included
+// partial may itself use @include() to pull in further nested partials.
+async function processIncludes(content: string, baseDir: string, depth = 0): Promise<string> {
+  if (!content.includes('@include(')) {
+    return content;
+  }
+  if (depth >= MAX_INCLUDE_DEPTH) {
+    throw new PentestError(
+      `@include() nesting exceeds max depth (${MAX_INCLUDE_DEPTH}) — check for a circular include`,
+      'prompt',
+      false,
+      { baseDir, depth },
+    );
+  }
+
   const includeRegex = /@include\(([^)]+)\)/g;
   const resolvedBase = path.resolve(baseDir);
 
@@ -251,7 +266,7 @@ async function processIncludes(content: string, baseDir: string): Promise<string
   for (const replacement of replacements) {
     content = replaceLiteral(content, replacement.placeholder, replacement.content);
   }
-  return content;
+  return processIncludes(content, baseDir, depth + 1);
 }
 
 /**

--- a/apps/worker/src/services/validate-authentication.ts
+++ b/apps/worker/src/services/validate-authentication.ts
@@ -122,16 +122,45 @@ export async function validateAuthentication(input: ValidateAuthInput): Promise<
   });
 
   const stateFile = authStateFile(auditSession.sessionMetadata);
-  await rm(stateFile, { force: true });
 
-  const prompt = await loadPrompt(
-    AGENT_NAME,
-    { webUrl, repoPath, AUTH_STATE_FILE: stateFile },
-    distributedConfig,
-    pipelineTestingMode ?? false,
-    logger,
-    promptDir,
-  );
+  try {
+    await rm(stateFile, { force: true });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return err(
+      new PentestError(
+        `Failed to clear stale authentication state at ${stateFile}: ${detail}`,
+        'filesystem',
+        true,
+        { stateFile, originalError: detail },
+        ErrorCode.AGENT_EXECUTION_FAILED,
+      ),
+    );
+  }
+
+  let prompt: string;
+  try {
+    prompt = await loadPrompt(
+      AGENT_NAME,
+      { webUrl, repoPath, AUTH_STATE_FILE: stateFile },
+      distributedConfig,
+      pipelineTestingMode ?? false,
+      logger,
+      promptDir,
+    );
+  } catch (error) {
+    // loadPrompt throws PentestError directly rather than returning a Result —
+    // convert to satisfy this function's Result-only contract.
+    if (error instanceof PentestError) {
+      return err(error);
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    return err(
+      new PentestError(`Failed to build authentication validation prompt: ${detail}`, 'prompt', false, {
+        originalError: detail,
+      }),
+    );
+  }
 
   await auditSession.startAgent(AGENT_NAME, prompt, attemptNumber);
   const startTime = Date.now();

--- a/apps/worker/src/temporal/activities.ts
+++ b/apps/worker/src/temporal/activities.ts
@@ -666,22 +666,23 @@ export async function syncCodePathDenyRules(input: ActivityInput): Promise<void>
 /**
  * Assemble the final report by concatenating per-class deliverables.
  *
- * Under exploit=true, each exploit agent has produced `*_exploitation_evidence.md`
- * directly. Under exploit=false, exploit agents didn't run; we deterministically
- * render `*_findings.md` from each `*_exploitation_queue.json` first, then assemble.
+ * Renders `*_findings.md` from each `*_exploitation_queue.json` first — this is a
+ * no-op per class when `*_exploitation_evidence.md` already exists. That covers not
+ * just exploit=false (exploit agents never ran) but also exploit=true runs where one
+ * class's exploit agent failed or never ran (partial run): without this fallback the
+ * class would have neither an evidence nor a findings file, and assembleFinalReport
+ * would silently omit it — reporting confirmed queue findings as if none existed.
  */
-export async function assembleReportActivity(input: ActivityInput, exploit: boolean): Promise<void> {
+export async function assembleReportActivity(input: ActivityInput): Promise<void> {
   const { repoPath, deliverablesSubdir } = input;
   const logger = createActivityLogger();
 
-  if (!exploit) {
-    logger.info('Rendering per-class findings from analysis queues...');
-    try {
-      await renderFindingsFromQueues(repoPath, deliverablesSubdir, logger);
-    } catch (error) {
-      const err = error as Error;
-      logger.warn(`Error rendering findings from queues: ${err.message}`);
-    }
+  logger.info('Rendering per-class findings from analysis queues...');
+  try {
+    await renderFindingsFromQueues(repoPath, deliverablesSubdir, logger);
+  } catch (error) {
+    const err = error as Error;
+    logger.warn(`Error rendering findings from queues: ${err.message}`);
   }
 
   logger.info('Assembling deliverables from specialist agents...');

--- a/apps/worker/src/temporal/activities.ts
+++ b/apps/worker/src/temporal/activities.ts
@@ -948,6 +948,15 @@ async function findLatestCommit(gitDir: string, commitHashes: string[]): Promise
   return result.stdout.trim();
 }
 
+// Substrings git itself uses when `cat-file -e <hash>^{commit}` fails because the object
+// genuinely doesn't exist — as opposed to a transient failure (lock exhaustion, FS error).
+const MISSING_COMMIT_PATTERNS = ['not a valid object name', 'bad object', 'unknown revision'];
+
+function isMissingCommitError(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase();
+  return MISSING_COMMIT_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
 /**
  * Restore deliverables git to a checkpoint.
  * Operates on the private git inside workspace deliverables, not the user's repo.
@@ -970,7 +979,13 @@ export async function restoreGitCheckpoint(
       deliverablesPath,
       'verify checkpoint hash exists',
     );
-  } catch {
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (!isMissingCommitError(errorMessage)) {
+      // A transient failure (lock exhaustion, FS error) — not proof the checkpoint is
+      // missing. Propagate so Temporal retries instead of silently skipping cleanup.
+      throw error;
+    }
     logger.info(`Checkpoint hash not found in clone, skipping git reset: ${checkpointHash}`);
     return;
   }

--- a/apps/worker/src/temporal/activities.ts
+++ b/apps/worker/src/temporal/activities.ts
@@ -23,7 +23,7 @@ import { writePlaywrightStealthConfig } from '../ai/playwright-config-writer.js'
 import { AuditSession } from '../audit/index.js';
 import type { ResumeAttempt } from '../audit/metrics-tracker.js';
 import { authStateFile, generateAuditPath, generateSessionJsonPath, type SessionMetadata } from '../audit/utils.js';
-import type { WorkflowSummary } from '../audit/workflow-logger.js';
+import { closeWorkflowLogger, type WorkflowSummary } from '../audit/workflow-logger.js';
 import type { CheckpointContext } from '../interfaces/checkpoint-provider.js';
 import { DEFAULT_DELIVERABLES_SUBDIR, deliverablesDir, resolveSessionJsonPath } from '../paths.js';
 import { getAgentGitPaths } from '../services/agent-git-paths.js';
@@ -1140,6 +1140,9 @@ export async function logWorkflowComplete(input: ActivityInput, summary: Workflo
 
   // 8. Clean up container
   removeContainer(workflowId);
+
+  // 9. This is the last write to workflow.log for this session — release its file handle.
+  await closeWorkflowLogger(sessionMetadata.id);
 }
 
 /**

--- a/apps/worker/src/temporal/workflows.ts
+++ b/apps/worker/src/temporal/workflows.ts
@@ -33,7 +33,6 @@ import {
   workflowInfo,
 } from '@temporalio/workflow';
 import type { AgentName, VulnType } from '../types/agents.js';
-import { ALL_AGENTS } from '../types/agents.js';
 import { ALL_VULN_CLASSES, type VulnClass } from '../types/config.js';
 import type * as activities from './activities.js';
 import type { ActivityInput } from './activities.js';
@@ -274,8 +273,10 @@ export async function pentestPipeline(input: PipelineInput): Promise<PipelineSta
       input.deliverablesSubdir,
     );
 
-    // 2. Restore git workspace and clean up incomplete deliverables
-    const incompleteAgents = ALL_AGENTS.filter(
+    // 2. Restore git workspace and clean up incomplete deliverables. Scoped to this run's
+    // expectedAgents (not ALL_AGENTS) so a class-scoped run doesn't treat agents outside
+    // its locked vuln_classes/exploit scope as "incomplete" and target them for cleanup.
+    const incompleteAgents = expectedAgents.filter(
       (agentName) => !resumeState?.completedAgents.includes(agentName),
     ) as AgentName[];
 

--- a/apps/worker/src/temporal/workflows.ts
+++ b/apps/worker/src/temporal/workflows.ts
@@ -647,7 +647,7 @@ export async function pentestPipeline(input: PipelineInput): Promise<PipelineSta
       await a.logPhaseTransition(activityInput, 'reporting', 'start');
 
       // First, assemble the concatenated report from per-class deliverables
-      await a.assembleReportActivity(activityInput, exploit);
+      await a.assembleReportActivity(activityInput);
 
       // Then run the report agent to add executive summary and clean up
       state.agentMetrics.report = await a.runReportAgent(activityInput);

--- a/apps/worker/src/utils/formatting.ts
+++ b/apps/worker/src/utils/formatting.ts
@@ -18,13 +18,18 @@ export function formatDuration(ms: number): string {
     return `${ms}ms`;
   }
 
-  const seconds = ms / 1000;
-  if (seconds < 60) {
-    return `${seconds.toFixed(1)}s`;
+  const totalSeconds = ms / 1000;
+  // Round before branching — otherwise a value like 59.95s takes the sub-minute
+  // branch (seconds < 60) but toFixed(1) then rounds its *display* up to "60.0s",
+  // which reads as a full minute while the unit says seconds.
+  const roundedSeconds = Math.round(totalSeconds * 10) / 10;
+  if (roundedSeconds < 60) {
+    return `${roundedSeconds.toFixed(1)}s`;
   }
 
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = Math.floor(seconds % 60);
+  const wholeSeconds = Math.round(totalSeconds);
+  const minutes = Math.floor(wholeSeconds / 60);
+  const remainingSeconds = wholeSeconds % 60;
   return `${minutes}m ${remainingSeconds}s`;
 }
 


### PR DESCRIPTION
- classifyErrorForTemporal now honors a PentestError's explicit retryable flag when no ErrorCode is set, instead of letting message substring matching override author intent (was flipping intentionally retryable queue-validation failures to non-retryable, and vice versa for unrecoverable preflight config errors).
- runPiPrompt's billing/session-limit text classification now only applies to turns the harness itself flags as errors, not every successful turn's assistant text — legitimate pentest report prose (e.g. "no usage limit enforced") could otherwise discard a successful, paid-for agent run.
- runPiPrompt's catch block now preserves a caught PentestError's code and retryable fields instead of rebuilding them from generic string heuristics, restoring the billing/spending-cap retry path.
- restoreGitCheckpoint now only treats a checkpoint-existence check failure as "checkpoint missing" for git's actual missing-object errors; any other failure (lock exhaustion, FS error) propagates instead of silently skipping the reset/clean/deliverable-cleanup steps during resume.