### PR TITLE
fix(config): let gateway-scoped TOML key shadow leaked env var

### DIFF
--- a/apps/cli/src/config/resolver.ts
+++ b/apps/cli/src/config/resolver.ts
@@ -16,6 +16,7 @@ import {
   GENERIC_API_KEY_ENV,
   isCuratedProvider,
   parseModelSpec,
+  PROVIDER_API_KEY_ENV,
 } from '../model-spec.js';
 
 // === TOML ↔ Env Mapping ===
@@ -261,12 +262,23 @@ export function resolveConfig(): void {
     );
   }
 
-  for (const mapping of CONFIG_MAP) {
-    if (process.env[mapping.env]) continue;
+  // 5. A gateway-scoped curated key overrides an env var, because that key is
+  //    only meaningful for the named gateway. Only applies when base_url is set
+  //    for the same provider that core.model selects.
+  const selectedProvider = parseModelSpec(toml.core?.model ?? DEFAULT_MODEL_SPEC);
+  const gatewayBaseUrl = typeof toml.core?.base_url === 'string' ? toml.core.base_url : undefined;
+  const gatewayScopedOverride =
+    typeof selectedProvider !== 'string' && isCuratedProvider(selectedProvider.providerId) && gatewayBaseUrl
+      ? PROVIDER_API_KEY_ENV[selectedProvider.providerId][0]
+      : undefined;
 
+  for (const mapping of CONFIG_MAP) {
     const value = getTomlValue(toml, mapping);
-    if (value) {
-      process.env[mapping.env] = value;
-    }
+    if (!value) continue;
+
+    const isGatewayScopedKey = mapping.env === gatewayScopedOverride;
+    if (process.env[mapping.env] && !isGatewayScopedKey) continue;
+
+    process.env[mapping.env] = value;
   }
 }

--- a/apps/worker/src/temporal/workflows.ts
+++ b/apps/worker/src/temporal/workflows.ts
@@ -117,9 +117,11 @@ const PREFLIGHT_RETRY = {
   nonRetryableErrorTypes: PRODUCTION_RETRY.nonRetryableErrorTypes,
 };
 
-// Activity proxy for preflight validation (short timeout)
+// Activity proxy for preflight validation. Must be long enough for a remote
+// gateway's first token: model probe + a short pi session can take several
+// minutes when the endpoint is a proxy with cold model loading.
 const preflightActs = proxyActivities<typeof activities>({
-  startToCloseTimeout: '2 minutes',
+  startToCloseTimeout: '15 minutes',
   heartbeatTimeout: '2 minutes',
   retry: PREFLIGHT_RETRY,
   cancellationType: ActivityCancellationType.TRY_CANCEL,


### PR DESCRIPTION
Fixes #436.

## Why

When `~/.shannon/config.toml` pairs a curated provider with `core.base_url`, a shell-exported env var for the same provider silently wins over the gateway-scoped `api_key` in TOML, and the wrong credential is forwarded to the gateway. Before this patch, running against an OpenAI-compatible LiteLLM gateway with a real `OPENAI_API_KEY` on the host (e.g. for other tooling) reliably failed preflight with HTTP 401 `token_not_found` even though `npx @keygraph/shannon setup` had produced a correct config.

## What

Two files, ~22 changed lines:

1. **`apps/cli/src/config/resolver.ts`** — during npx-mode TOML injection, detect a curated provider + `core.base_url` combination and let that provider's first credential env var be overwritten by the TOML value. Behavior is unchanged for direct-provider users (no `base_url`) and for uncurated providers.

2. **`apps/worker/src/temporal/workflows.ts`** — bump `runPreflightValidation`'s `startToCloseTimeout` from 2m to 15m. Sized for remote LiteLLM gateways with cold model loading; the 2m default was killing scans after credential shadowing was fixed. Heartbeat stays at 2m so genuine stalls still surface quickly.

## Verification

- Built CLI from this branch: `pnpm --filter @keygraph/shannon build`
- Ran the previously failing command end-to-end:

  ```
  node apps/cli/dist/index.mjs start -u https://gateway-llm.siam.ai -r /path/to/repo
  ```

  Before: preflight failed with `OpenAI API error (401) ... token_not_found` containing the **shell** key suffix.
  After: preflight proceeds to `Validating custom endpoint (https://gateway-llm.siam.ai) via pi...` — credential accepted by the gateway.

See #436 for a detailed repro and the diff-commentary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)