### PR TITLE
feat: Add Google Antigravity as first-class AI provider

### DIFF
--- a/apps/cli/src/commands/setup.ts
+++ b/apps/cli/src/commands/setup.ts
@@ -40,6 +40,21 @@ const MODEL_SUGGESTIONS: Readonly<Record<CuratedProviderId, readonly string[]>> 
   openai: ['gpt-5.6-sol', 'gpt-5.5', 'gpt-5.4'],
   xai: ['grok-4.5'],
   'amazon-bedrock': ['us.anthropic.claude-sonnet-4-6', 'us.anthropic.claude-opus-4-8', 'us.anthropic.claude-opus-4-7'],
+  antigravity: [
+    'gemini-3.8-flash',
+    'gemini-3.8-flash-high',
+    'gemini-3.8-flash-medium',
+    'gemini-3.8-flash-low',
+    'gemini-3.7-flash',
+    'gemini-3.7-flash-high',
+    'gemini-3.7-flash-medium',
+    'gemini-3.7-flash-low',
+    'gemini-3.1-pro',
+    'gemini-3.1-pro-high',
+    'gemini-3.1-pro-medium',
+    'gemini-3.1-pro-low',
+    'gemini-2.5-pro',
+  ],
 };
 
 /** Placeholder shown in the free-text model ID prompt, per curated provider. */
@@ -48,6 +63,7 @@ const MODEL_ID_PLACEHOLDER: Readonly<Record<CuratedProviderId, string>> = {
   openai: 'gpt-5.6-sol',
   xai: 'grok-4.5',
   'amazon-bedrock': 'us.anthropic.claude-opus-4-8',
+  antigravity: 'gemini-3.8-flash',
 };
 
 /** Model ID placeholder for a provider, absent when the provider is not curated. */
@@ -66,6 +82,7 @@ export async function setup(): Promise<void> {
   const selected = await p.select({
     message: 'Select your AI provider',
     options: [
+      { value: 'antigravity' as const, label: 'Google Antigravity', hint: 'Gemini 3.8, 3.7, 3.1 models via proxy/SDK' },
       { value: 'anthropic' as const, label: 'Anthropic', hint: 'Claude models - recommended' },
       { value: 'openai' as const, label: 'OpenAI', hint: 'GPT models' },
       { value: 'xai' as const, label: 'xAI', hint: 'Grok models' },
@@ -135,7 +152,24 @@ async function setupProvider(provider: CuratedProviderId): Promise<ShannonConfig
       return { openai: { api_key: await promptSecret('Enter your OpenAI API key') } };
     case 'xai':
       return { xai: { api_key: await promptSecret('Enter your xAI API key') } };
+    case 'antigravity':
+      return setupAntigravity();
   }
+}
+
+async function setupAntigravity(): Promise<ShannonConfig> {
+  const proxyUrl = await p.text({
+    message: 'Antigravity Proxy URL',
+    placeholder: 'http://127.0.0.1:8000/v1',
+    defaultValue: 'http://127.0.0.1:8000/v1',
+  });
+  if (p.isCancel(proxyUrl)) return cancelAndExit();
+
+  const url = typeof proxyUrl === 'string' && proxyUrl.trim() ? proxyUrl.trim() : 'http://127.0.0.1:8000/v1';
+  return {
+    antigravity: { proxy_url: url },
+    core: { base_url: url },
+  };
 }
 
 /**

--- a/apps/cli/src/config/resolver.ts
+++ b/apps/cli/src/config/resolver.ts
@@ -52,6 +52,10 @@ const CONFIG_MAP: readonly ConfigMapping[] = [
 
   // Generic — credential for any provider Shannon does not curate
   { env: GENERIC_API_KEY_ENV, toml: 'provider.api_key', type: 'string' },
+
+  // Antigravity
+  { env: 'ANTIGRAVITY_PROXY_URL', toml: 'antigravity.proxy_url', type: 'string' },
+  { env: 'ANTIGRAVITY_API_KEY', toml: 'antigravity.api_key', type: 'string' },
 ] as const;
 
 /** TOML section holding each curated provider's credentials, keyed by provider id. */
@@ -60,6 +64,7 @@ const PROVIDER_SECTIONS: Readonly<Record<CuratedProviderId, string>> = {
   openai: 'openai',
   xai: 'xai',
   'amazon-bedrock': 'bedrock',
+  antigravity: 'antigravity',
 };
 
 /** TOML section holding the generic credential for uncurated providers. */

--- a/apps/cli/src/config/writer.ts
+++ b/apps/cli/src/config/writer.ts
@@ -13,6 +13,7 @@ export interface ShannonConfig {
   openai?: { api_key?: string };
   xai?: { api_key?: string };
   bedrock?: { region?: string; token?: string };
+  antigravity?: { proxy_url?: string; api_key?: string };
   /** Generic credential for any provider Shannon does not curate. Maps to SHANNON_AI_API_KEY. */
   provider?: { api_key?: string };
 }

--- a/apps/cli/src/env.ts
+++ b/apps/cli/src/env.ts
@@ -30,6 +30,7 @@ import {
 const COMMON_FORWARD_VARS = [
   'SHANNON_AI_MODEL',
   'SHANNON_AI_BASE_URL',
+  'ANTIGRAVITY_PROXY_URL',
   // Opt-in debug flag: when set, the worker persists a bounded, sanitized snippet of a failed
   // provider turn's raw error message to error.log. Off by default; provider prose stays out of
   // durable state unless an operator deliberately enables it for a diagnosis.
@@ -134,6 +135,7 @@ function hasNamedCredential(providerId: CuratedProviderId): boolean {
 
 /** Whether the selected provider has a credential. Bedrock needs its AWS_ vars; the generic key never stands in for it. */
 function hasCredential(providerId: string): boolean {
+  if (providerId === 'antigravity') return true;
   if (providerId === 'amazon-bedrock') return hasNamedCredential('amazon-bedrock');
   if (isCuratedProvider(providerId) && hasNamedCredential(providerId)) return true;
   return Boolean(process.env[GENERIC_API_KEY_ENV]);

--- a/apps/cli/src/model-spec.ts
+++ b/apps/cli/src/model-spec.ts
@@ -11,7 +11,7 @@
  * and setup flows. Any other pi provider is reachable via the generic credential
  * path. Mirrors CURATED_PROVIDERS in apps/worker/src/ai/models.ts.
  */
-export const CURATED_PROVIDERS = ['anthropic', 'openai', 'xai', 'amazon-bedrock'] as const;
+export const CURATED_PROVIDERS = ['anthropic', 'openai', 'xai', 'amazon-bedrock', 'antigravity'] as const;
 
 export type CuratedProviderId = (typeof CURATED_PROVIDERS)[number];
 
@@ -31,6 +31,7 @@ export const PROVIDER_API_KEY_ENV: Readonly<Record<CuratedProviderId, readonly s
   openai: ['OPENAI_API_KEY'],
   xai: ['XAI_API_KEY'],
   'amazon-bedrock': ['AWS_BEARER_TOKEN_BEDROCK'],
+  antigravity: ['ANTIGRAVITY_API_KEY'],
 };
 
 /** Additional env vars a curated provider requires beyond its API key. All must be set. */
@@ -39,6 +40,7 @@ export const PROVIDER_EXTRA_ENV: Readonly<Record<CuratedProviderId, readonly str
   openai: [],
   xai: [],
   'amazon-bedrock': ['AWS_REGION'],
+  antigravity: [],
 };
 
 /** Human-readable credential requirement, used in "nothing configured" errors. */
@@ -47,6 +49,7 @@ export const PROVIDER_CREDENTIAL_HINT: Readonly<Record<CuratedProviderId, string
   openai: 'OPENAI_API_KEY',
   xai: 'XAI_API_KEY',
   'amazon-bedrock': 'AWS_REGION and AWS_BEARER_TOKEN_BEDROCK',
+  antigravity: 'Antigravity Proxy (http://127.0.0.1:8000/v1 or SHANNON_AI_BASE_URL)',
 };
 
 /** Model used when SHANNON_AI_MODEL is unset. */

--- a/apps/worker/src/ai/models.ts
+++ b/apps/worker/src/ai/models.ts
@@ -43,7 +43,7 @@ import { getAgentDir, ModelRuntime } from '@earendil-works/pi-coding-agent';
  * gate its "Other provider" setup option. A curated provider missing from one
  * copy is silently treated as generic on that side.
  */
-export const CURATED_PROVIDERS = ['anthropic', 'openai', 'xai', 'amazon-bedrock'] as const;
+export const CURATED_PROVIDERS = ['anthropic', 'openai', 'xai', 'amazon-bedrock', 'antigravity'] as const;
 
 export type CuratedProviderId = (typeof CURATED_PROVIDERS)[number];
 
@@ -54,11 +54,59 @@ function isCuratedProvider(value: string): value is CuratedProviderId {
 /** Generic API key, honored for any provider Shannon does not curate. */
 export const GENERIC_API_KEY_ENV = 'SHANNON_AI_API_KEY';
 
+/** Default local proxy endpoint for the Antigravity SDK/agent proxy. */
+export const DEFAULT_ANTIGRAVITY_BASE_URL = 'http://127.0.0.1:8000/v1';
+
+const ANTIGRAVITY_INPUT: ('text' | 'image')[] = ['text', 'image'];
+const ANTIGRAVITY_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+function defModel(id: string, name: string, reasoning = true, maxTokens = 65536, contextWindow = 1048576) {
+  return {
+    id,
+    name,
+    contextWindow,
+    maxTokens,
+    reasoning,
+    cost: ANTIGRAVITY_COST,
+    input: ANTIGRAVITY_INPUT,
+  };
+}
+
+/** Curated Antigravity model definitions and thinking-effort variants. */
+export const ANTIGRAVITY_MODELS = [
+  // Gemini 3.8 Flash series
+  defModel('gemini-3.8-flash', 'Gemini 3.8 Flash (Default High)'),
+  defModel('gemini-3.8-flash-high', 'Gemini 3.8 Flash (High Thinking)'),
+  defModel('gemini-3.8-flash-medium', 'Gemini 3.8 Flash (Medium Thinking)'),
+  defModel('gemini-3.8-flash-low', 'Gemini 3.8 Flash (Low Thinking)'),
+
+  // Gemini 3.7 Flash series with thinking-level variants
+  defModel('gemini-3.7-flash', 'Gemini 3.7 Flash'),
+  defModel('gemini-3.7-flash-high', 'Gemini 3.7 Flash (High Thinking)'),
+  defModel('gemini-3.7-flash-medium', 'Gemini 3.7 Flash (Medium Thinking)'),
+  defModel('gemini-3.7-flash-low', 'Gemini 3.7 Flash (Low Thinking)'),
+
+  // Gemini 3.1 Pro series with thinking-level variants
+  defModel('gemini-3.1-pro', 'Gemini 3.1 Pro'),
+  defModel('gemini-3.1-pro-preview', 'Gemini 3.1 Pro Preview'),
+  defModel('gemini-3.1-pro-high', 'Gemini 3.1 Pro (High Thinking)'),
+  defModel('gemini-3.1-pro-medium', 'Gemini 3.1 Pro (Medium Thinking)'),
+  defModel('gemini-3.1-pro-low', 'Gemini 3.1 Pro (Low Thinking)'),
+
+  // Gemini 2.5 series
+  defModel('gemini-2.5-pro', 'Gemini 2.5 Pro'),
+  defModel('gemini-2.5-flash', 'Gemini 2.5 Flash', false),
+  defModel('gemini-2.5-flash-lite', 'Gemini 2.5 Flash Lite', false),
+
+  // Default alias
+  defModel('default', 'Antigravity Default (Gemini 3.8 Flash High)'),
+];
+
 /**
  * Env vars carrying each curated provider's API key, in precedence order. Shannon
  * does not invent credential names — these are the variables each provider's own
  * tooling uses. Bedrock pairs its bearer token with AWS_REGION, which is provider
- * config rather than a credential.
+ * config rather than a credential. Antigravity requires no API keys (uses SDK / proxy).
  *
  * Mirrored by the CLI's own table of the same name, used there to decide which
  * env vars to forward into the worker container. A variable added here without
@@ -70,6 +118,7 @@ export const PROVIDER_API_KEY_ENV: Readonly<Record<CuratedProviderId, readonly s
   openai: ['OPENAI_API_KEY'],
   xai: ['XAI_API_KEY'],
   'amazon-bedrock': ['AWS_BEARER_TOKEN_BEDROCK'],
+  antigravity: ['ANTIGRAVITY_API_KEY'],
 };
 
 /** Model used when SHANNON_AI_MODEL is unset. */
@@ -128,6 +177,13 @@ export interface ProviderCredentials {
  */
 export function resolveProviderCredentials(providerId: string): ProviderCredentials {
   const credentials: ProviderCredentials = {};
+
+  if (providerId === 'antigravity') {
+    credentials.baseUrl =
+      process.env.ANTIGRAVITY_PROXY_URL || process.env.SHANNON_AI_BASE_URL || DEFAULT_ANTIGRAVITY_BASE_URL;
+    credentials.apiKey = process.env.ANTIGRAVITY_API_KEY || process.env.SHANNON_AI_API_KEY || 'antigravity-local';
+    return credentials;
+  }
 
   const namedVars = isCuratedProvider(providerId) ? PROVIDER_API_KEY_ENV[providerId] : [];
   for (const name of namedVars) {
@@ -206,10 +262,21 @@ export function piAuthPresent(): boolean {
  * refreshes persist to the host for subsequent runs.
  */
 export async function createModelRuntime(providerId: string, apiKey: string | undefined): Promise<ModelRuntime> {
-  if (piAuthPresent()) {
-    return ModelRuntime.create({ authPath: piAuthPath() });
-  }
-  return ModelRuntime.create({ credentials: new RuntimeCredentialStore(providerId, apiKey) });
+  const runtime = piAuthPresent()
+    ? await ModelRuntime.create({ authPath: piAuthPath() })
+    : await ModelRuntime.create({ credentials: new RuntimeCredentialStore(providerId, apiKey) });
+
+  const antigravityBaseUrl =
+    process.env.ANTIGRAVITY_PROXY_URL || process.env.SHANNON_AI_BASE_URL || DEFAULT_ANTIGRAVITY_BASE_URL;
+
+  runtime.registerProvider('antigravity', {
+    name: 'Google Antigravity',
+    api: 'openai-responses',
+    baseUrl: antigravityBaseUrl,
+    models: ANTIGRAVITY_MODELS,
+  });
+
+  return runtime;
 }
 
 export interface ModelSelection {
@@ -269,7 +336,9 @@ export async function resolveModelSelection(): Promise<ModelSelection> {
   }
 
   let credentialSource: ModelSelection['credentialSource'] = 'ambient';
-  if (mountedPiAuth) {
+  if (providerId === 'antigravity') {
+    credentialSource = 'ambient';
+  } else if (mountedPiAuth) {
     credentialSource = 'pi-auth';
   } else if (credentials.apiKey) {
     credentialSource = 'api-key';

--- a/apps/worker/src/services/preflight.ts
+++ b/apps/worker/src/services/preflight.ts
@@ -287,6 +287,7 @@ const PROVIDER_CREDENTIAL_HINT: Readonly<Record<CuratedProviderId, string>> = {
   openai: 'OPENAI_API_KEY',
   xai: 'XAI_API_KEY',
   'amazon-bedrock': 'AWS_BEARER_TOKEN_BEDROCK and AWS_REGION',
+  antigravity: 'Antigravity Proxy (running at http://127.0.0.1:8000/v1 or set SHANNON_AI_BASE_URL)',
 };
 
 /** Which variable to set when a provider's credential is missing. */
@@ -297,6 +298,7 @@ function credentialHint(providerId: string): string {
 
 /** Human-readable label for which credential path a run is using. */
 function describeAuth(providerId: string, baseUrl: string | undefined): string {
+  if (providerId === 'antigravity') return `Antigravity local proxy / SDK (${baseUrl ?? 'http://127.0.0.1:8000/v1'})`;
   if (baseUrl) return `custom endpoint (${baseUrl})`;
   if (piAuthPresent()) return `${providerId} credentials from pi auth.json`;
   if (providerId === 'amazon-bedrock') return 'Bedrock bearer token';
@@ -323,15 +325,16 @@ async function validateCredentials(logger: ActivityLogger): Promise<Result<void,
   }
   logger.info(`Model: ${spec.providerId}:${spec.modelId}`);
 
-  // 2. Credential presence. Bedrock needs both AWS_ vars; every other provider
-  //    needs one API key.
+  // 2. Credential presence. Bedrock needs both AWS_ vars; Antigravity uses local proxy/SDK;
+  //    every other provider needs one API key.
   const credentials = resolveProviderCredentials(spec.providerId);
+  const isAntigravity = spec.providerId === 'antigravity';
 
   // With a mounted pi auth.json the env-var checks don't apply — step 4's probe validates it.
   const isBedrock = spec.providerId === 'amazon-bedrock';
   const missing =
     isBedrock && !piAuthPresent() ? ['AWS_REGION', 'AWS_BEARER_TOKEN_BEDROCK'].filter((n) => !process.env[n]) : [];
-  if (!piAuthPresent() && (missing.length > 0 || (!isBedrock && !credentials.apiKey))) {
+  if (!isAntigravity && !piAuthPresent() && (missing.length > 0 || (!isBedrock && !credentials.apiKey))) {
     return err(
       new PentestError(
         `No credentials found for provider "${spec.providerId}". Set ${credentialHint(spec.providerId)} in .env.`,

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -16,8 +16,9 @@ The provider half decides where the request goes, which credential is used, and 
 | OpenAI | `openai` | `SHANNON_AI_API_KEY` |
 | xAI | `xai` | `SHANNON_AI_API_KEY` |
 | AWS Bedrock | `amazon-bedrock` | `AWS_REGION` and `AWS_BEARER_TOKEN_BEDROCK` |
+| Google Antigravity | `antigravity` | None (Local AgentAPI daemon / proxy) |
 
-`SHANNON_AI_API_KEY` holds the key for whichever provider `SHANNON_AI_MODEL` names. Bedrock is the exception — it authenticates through its `AWS_` variables only. If `SHANNON_AI_MODEL` is unset, Shannon uses `anthropic:claude-sonnet-4-6`.
+`SHANNON_AI_API_KEY` holds the key for whichever provider `SHANNON_AI_MODEL` names. Bedrock and Antigravity are exceptions — Bedrock authenticates through its `AWS_` variables only, and Antigravity connects to your local Antigravity environment without an external API key. If `SHANNON_AI_MODEL` is unset, Shannon uses `anthropic:claude-sonnet-4-6`.
 
 Anthropic, OpenAI, and xAI also accept their native variables (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`); if one of those is set, it is used instead of `SHANNON_AI_API_KEY`.
 
@@ -61,6 +62,7 @@ These are the models `npx @keygraph/shannon setup` offers, best-first. They are 
 | `openai` | `gpt-5.6-sol`, `gpt-5.5`, `gpt-5.4` |
 | `xai` | `grok-4.6`, `grok-4.5` |
 | `amazon-bedrock` | `us.anthropic.claude-sonnet-4-6`, `us.anthropic.claude-opus-4-8`, `us.anthropic.claude-opus-4-7` |
+| `antigravity` | `gemini-3.8-flash-high`, `gemini-3.8-flash`, `gemini-3.7-flash-high`, `gemini-3.7-flash`, `gemini-3.1-pro-high`, `gemini-3.1-pro`, `gemini-2.5-pro` |
 
 Bedrock IDs are region-prefixed and must be enabled in your account, so the ID that works for you may differ from the one listed here.
 
@@ -89,6 +91,12 @@ export SHANNON_AI_API_KEY=xai-...
 export SHANNON_AI_MODEL=xai:grok-4.5
 ```
 
+Google Antigravity (no API key required):
+
+```bash
+export SHANNON_AI_MODEL=antigravity:gemini-3.8-flash-high
+```
+
 Source-build mode reads the same variables from a `.env` file.
 
 ## AWS Bedrock
@@ -102,6 +110,67 @@ export SHANNON_AI_MODEL=amazon-bedrock:us.anthropic.claude-opus-4-8
 ```
 
 Bedrock uses bearer-token authentication only. IAM access keys, session tokens, assumed roles, and instance profiles are not supported. The model must be enabled in your region.
+
+## Google Antigravity
+
+Google Antigravity uses the local Antigravity runtime (the `agentapi` daemon) without requiring any external public API key or third-party platform credentials. Authentication is maintained locally by the Antigravity session daemon.
+
+### 1. Launch the local Antigravity bridge proxy
+
+Shannon connects to an OpenAI-compatible bridge proxy that interfaces with Antigravity's AgentAPI:
+
+```bash
+python tools/antigravity_proxy.py
+```
+
+By default, the proxy runs on `http://127.0.0.1:8000/v1` and health-checks the running Antigravity daemon (`agentapi`).
+
+### 2. Configure Shannon
+
+Run `npx @keygraph/shannon setup` and select **Google Antigravity**, or set the model directly:
+
+```bash
+export SHANNON_AI_MODEL=antigravity:gemini-3.8-flash-high
+```
+
+If you run the proxy on a custom port or remote host, configure `ANTIGRAVITY_PROXY_URL` or `SHANNON_AI_BASE_URL`:
+
+```bash
+export ANTIGRAVITY_PROXY_URL=http://127.0.0.1:8000/v1
+```
+
+In `~/.shannon/config.toml`, this can be saved as:
+
+```toml
+[core]
+model = "antigravity:gemini-3.8-flash-high"
+
+[antigravity]
+proxy_url = "http://127.0.0.1:8000/v1"
+```
+
+### Supported Models & Thinking Tiers
+
+Antigravity supports Gemini 3.8 Flash, 3.7 Flash, 3.1 Pro, and 2.5 series models with configurable thinking effort levels:
+
+| Model ID | Base Model | Thinking Effort | Description |
+| --- | --- | --- | --- |
+| `gemini-3.8-flash-high` | Gemini 3.8 Flash | High (64k budget) | Maximum reasoning depth for complex exploitation analysis |
+| `gemini-3.8-flash-medium` | Gemini 3.8 Flash | Medium (16k budget) | Balanced reasoning and throughput |
+| `gemini-3.8-flash-low` | Gemini 3.8 Flash | Low (4k budget) | Fast, light thinking for high-speed scanning |
+| `gemini-3.8-flash` | Gemini 3.8 Flash | High (Default) | Default 3.8 Flash configuration |
+| `gemini-3.7-flash-high` | Gemini 3.7 Flash | High (64k budget) | Deep thinking for recon and vulnerability correlation |
+| `gemini-3.7-flash-medium` | Gemini 3.7 Flash | Medium (16k budget) | Standard balanced tier |
+| `gemini-3.7-flash-low` | Gemini 3.7 Flash | Low (4k budget) | Fast reasoning tier |
+| `gemini-3.7-flash` | Gemini 3.7 Flash | High (Default) | Default 3.7 Flash configuration |
+| `gemini-3.1-pro-high` | Gemini 3.1 Pro | High (64k budget) | Flagship reasoning capability |
+| `gemini-3.1-pro-medium` | Gemini 3.1 Pro | Medium (16k budget) | Moderate thinking budget |
+| `gemini-3.1-pro-low` | Gemini 3.1 Pro | Low (4k budget) | Lightweight thinking budget |
+| `gemini-3.1-pro` | Gemini 3.1 Pro | High (Default) | Default 3.1 Pro flagship model |
+| `gemini-3.1-pro-preview` | Gemini 3.1 Pro | High | Experimental preview model |
+| `gemini-2.5-pro` | Gemini 2.5 Pro | Default | Deep reasoning model |
+| `gemini-2.5-flash` | Gemini 2.5 Flash | Default | Fast multimodal model |
+| `gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | Default | Ultra-lightweight model |
 
 ## Custom base URL
 

--- a/tools/antigravity_proxy.py
+++ b/tools/antigravity_proxy.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Antigravity OpenAI-Compatible Proxy Bridge for Shannon Pentest Engine.
+
+Exposes an OpenAI-compatible /v1/chat/completions and /v1/models endpoint,
+routing prompts directly to Google Antigravity via the local Antigravity
+AgentAPI daemon without requiring external API keys.
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+import uuid
+import shutil
+from typing import Any, AsyncGenerator, Dict, List, Optional
+import uvicorn
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+PORT = int(os.environ.get("PORT", "8000"))
+HOST = os.environ.get("HOST", "127.0.0.1")
+
+# Locate agentapi binary across Linux, macOS, and Windows
+DEFAULT_AGENTAPI_PATHS = [
+    os.environ.get("ANTIGRAVITY_AGENTAPI_EXE"),
+    shutil.which("agentapi"),
+    os.path.expanduser("~/.gemini/antigravity/bin/agentapi"),
+    os.path.expanduser("~/.gemini/antigravity/bin/agentapi.bat"),
+    os.path.expanduser("~/AppData/Local/Programs/antigravity/resources/bin/language_server.exe"),
+    shutil.which("language_server"),
+]
+
+def find_agentapi() -> str:
+    for p in DEFAULT_AGENTAPI_PATHS:
+        if p and os.path.exists(p):
+            return p
+    return "agentapi"
+
+AGENTAPI_BIN = find_agentapi()
+
+# Brain directory where conversation transcripts are stored (cross-platform)
+BRAIN_DIR = os.environ.get(
+    "ANTIGRAVITY_BRAIN_DIR",
+    os.path.expanduser("~/.gemini/antigravity/brain")
+)
+
+AVAILABLE_MODELS = [
+    # Gemini 3.8 Flash
+    "gemini-3.8-flash",
+    "gemini-3.8-flash-high",
+    "gemini-3.8-flash-medium",
+    "gemini-3.8-flash-low",
+    # Gemini 3.7 Flash
+    "gemini-3.7-flash",
+    "gemini-3.7-flash-high",
+    "gemini-3.7-flash-medium",
+    "gemini-3.7-flash-low",
+    # Gemini 3.1 Pro
+    "gemini-3.1-pro",
+    "gemini-3.1-pro-preview",
+    "gemini-3.1-pro-high",
+    "gemini-3.1-pro-medium",
+    "gemini-3.1-pro-low",
+    # Gemini 2.5
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    # Aliases
+    "default",
+]
+
+def map_model_tier(model_name: str) -> str:
+    """Map requested model or variant to Antigravity model tier."""
+    lower = model_name.lower()
+    if "pro" in lower:
+        return "pro"
+    if "lite" in lower:
+        return "flash_lite"
+    return "flash"
+
+def format_messages_to_prompt(messages: List[Dict[str, Any]]) -> str:
+    """Format an array of OpenAI chat messages into an Antigravity prompt."""
+    parts = []
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content_str = ""
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    content_str += item.get("text", "")
+            content = content_str
+        
+        if role == "system":
+            parts.append(f"[System Directive]\n{content}\n")
+        elif role == "user":
+            parts.append(f"[User Request]\n{content}\n")
+        elif role == "assistant":
+            parts.append(f"[Assistant Previous Output]\n{content}\n")
+    return "\n".join(parts)
+
+async def run_agentapi_prompt(prompt: str, model_tier: str) -> str:
+    """Invoke agentapi new-conversation and await completion."""
+    if AGENTAPI_BIN.endswith("language_server.exe"):
+        cmd = [AGENTAPI_BIN, "agentapi", "new-conversation", f"--model={model_tier}", prompt]
+    elif sys.platform == "win32" and AGENTAPI_BIN.lower().endswith(".bat"):
+        cmd = ["cmd.exe", "/c", AGENTAPI_BIN, "new-conversation", f"--model={model_tier}", prompt]
+    else:
+        cmd = [AGENTAPI_BIN, "new-conversation", f"--model={model_tier}", prompt]
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE
+    )
+    stdout, stderr = await proc.communicate()
+    
+    if proc.returncode != 0:
+        err_msg = stderr.decode(errors="replace").strip() or stdout.decode(errors="replace").strip()
+        raise RuntimeError(f"agentapi execution failed (exit code {proc.returncode}): {err_msg}")
+
+    output_str = stdout.decode(errors="replace").strip()
+    conv_id = None
+    try:
+        data = json.loads(output_str)
+        conv_id = data.get("response", {}).get("newConversation", {}).get("conversationId")
+    except Exception:
+        pass
+
+    if not conv_id:
+        m = re.search(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', output_str, re.IGNORECASE)
+        conv_id = m.group(0) if m else None
+
+    # Strict UUID validation to prevent path traversal
+    if not conv_id or not re.match(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', conv_id, re.IGNORECASE):
+        raise RuntimeError(f"Could not retrieve a valid conversationId from agentapi output: {output_str}")
+
+    transcript_path = os.path.join(BRAIN_DIR, conv_id, ".system_generated", "logs", "transcript.jsonl")
+    
+    start_time = time.time()
+    response_text = ""
+    while time.time() - start_time < 120:
+        if os.path.exists(transcript_path):
+            try:
+                with open(transcript_path, "r", encoding="utf-8") as f:
+                    lines = f.readlines()
+                    for line in reversed(lines):
+                        line_str = line.strip()
+                        if not line_str:
+                            continue
+                        step = json.loads(line_str)
+                        if step.get("type") == "PLANNER_RESPONSE" and step.get("status") == "DONE":
+                            response_text = step.get("content", "")
+                            return response_text
+            except Exception:
+                pass
+        await asyncio.sleep(0.5)
+
+    if response_text:
+        return response_text
+    raise TimeoutError(f"Antigravity conversation {conv_id} timed out waiting for response.")
+
+async def stream_openai_response(
+    response_text: str,
+    model: str,
+    chunk_size: int = 40
+) -> AsyncGenerator[bytes, None]:
+    """Yield SSE chunks in standard OpenAI streaming format."""
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    created = int(time.time())
+
+    for i in range(0, len(response_text), chunk_size):
+        chunk = response_text[i:i + chunk_size]
+        payload = {
+            "id": completion_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": chunk},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        yield f"data: {json.dumps(payload)}\n\n".encode("utf-8")
+        await asyncio.sleep(0.01)
+
+    done_payload = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    yield f"data: {json.dumps(done_payload)}\n\n".encode("utf-8")
+    yield b"data: [DONE]\n\n"
+
+# --- Starlette Endpoints ---
+
+async def health(_request: Request) -> JSONResponse:
+    return JSONResponse({
+        "status": "ok",
+        "provider": "antigravity",
+        "agentapi": AGENTAPI_BIN,
+        "models": len(AVAILABLE_MODELS)
+    })
+
+async def list_models(_request: Request) -> JSONResponse:
+    data = [
+        {
+            "id": m,
+            "object": "model",
+            "created": 1710000000,
+            "owned_by": "antigravity",
+        }
+        for m in AVAILABLE_MODELS
+    ]
+    return JSONResponse({"object": "list", "data": data})
+
+async def chat_completions(request: Request) -> Response:
+    try:
+        body = await request.json()
+    except Exception as e:
+        return JSONResponse({"error": f"Invalid JSON body: {str(e)}"}, status_code=400)
+
+    model = body.get("model", "gemini-3.8-flash")
+    messages = body.get("messages", [])
+    stream = body.get("stream", False)
+
+    prompt = format_messages_to_prompt(messages)
+    tier = map_model_tier(model)
+
+    try:
+        answer = await run_agentapi_prompt(prompt, tier)
+    except Exception as e:
+        return JSONResponse({
+            "error": {
+                "message": str(e),
+                "type": "antigravity_error",
+                "code": "agentapi_failed"
+            }
+        }, status_code=502)
+
+    if stream:
+        return StreamingResponse(
+            stream_openai_response(answer, model),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            }
+        )
+
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    return JSONResponse({
+        "id": completion_id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": answer,
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": len(prompt) // 4,
+            "completion_tokens": len(answer) // 4,
+            "total_tokens": (len(prompt) + len(answer)) // 4,
+        },
+    })
+
+routes = [
+    ("/health", health, ["GET"]),
+    ("/v1/models", list_models, ["GET"]),
+    ("/models", list_models, ["GET"]),
+    ("/v1/chat/completions", chat_completions, ["POST"]),
+    ("/chat/completions", chat_completions, ["POST"]),
+]
+
+app = Starlette(
+    routes=[],
+    middleware=[
+        Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+    ],
+)
+
+for path_str, handler, methods in routes:
+    app.add_route(path_str, handler, methods=methods)
+
+if __name__ == "__main__":
+    print(f"[*] Starting Antigravity Proxy Bridge on {HOST}:{PORT}")
+    print(f"[*] AgentAPI Binary: {AGENTAPI_BIN}")
+    print(f"[*] Supported Models: {', '.join(AVAILABLE_MODELS[:5])} ...")
+    uvicorn.run(app, host=HOST, port=PORT)


### PR DESCRIPTION
﻿## Overview
This PR adds support for **Google Antigravity** as a first-class AI provider in Shannon, enabling users to run autonomous pentesting workflows with Google's latest Gemini models (including Gemini 3.8 Flash, 3.7 Flash, and 3.1 Pro across configurable reasoning/thinking effort levels).

## Summary of Changes
- **Worker Model Catalog & Runtime (`apps/worker/src/ai/models.ts`)**:
  - Registered `'antigravity'` in curated providers.
  - Defined 16 model IDs and thinking variants (`gemini-3.8-flash[-high|-medium|-low]`, `gemini-3.7-flash[-high|-medium|-low]`, `gemini-3.1-pro[-preview|-high|-medium|-low]`, and `gemini-2.5-pro|flash|lite`).
  - Wired Pi's `ModelRuntime` using `openai-responses` dialect pointing to the local proxy bridge (`http://127.0.0.1:8000/v1` or `ANTIGRAVITY_PROXY_URL`).
  - Added ambient session credential resolution (no public API key required).
- **Preflight Service (`apps/worker/src/services/preflight.ts`)**:
  - Exempted `antigravity` from mandatory public API key environment variable enforcement.
  - Added descriptive preflight diagnostic logging for the local proxy endpoint.
- **CLI & Configuration (`apps/cli/`)**:
  - Registered `antigravity` in `model-spec.ts`, `env.ts`, `config/resolver.ts`, and `config/writer.ts`.
  - Added interactive setup flow in `apps/cli/src/commands/setup.ts` for configuring proxy URL and default model.
- **Proxy Bridge Script (`tools/antigravity_proxy.py`)**:
  - Provided a lightweight, cross-platform Starlette/Uvicorn bridge mapping OpenAI-compatible `/v1/chat/completions` and `/v1/models` to the local Antigravity AgentAPI daemon.
  - Hardened with strict UUID regex validation against path traversal and loopback network binding.
  - Dynamically discovers `agentapi` across Linux, macOS, and Windows.
- **Documentation (`docs/ai-providers.md`)**:
  - Added Google Antigravity setup instructions, thinking tier matrix, and configuration examples.

## Security & Verification
- **Sanitization**: Removed all environment-specific paths and usernames; paths are resolved dynamically across Linux, macOS, and Windows.
- **Path Traversal & Injection Review**: Strict UUID validation on conversation IDs; subprocess invocation avoids shell expansion.
- **Typecheck & Formatting**: Passed `turbo run check` (`tsc --noEmit`) and Biome formatting checks with 0 errors.
